### PR TITLE
feat: Émettre healthdcatap:hasStructuredData (dérivé de schemaMetadata)

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -58,6 +58,7 @@ vérifié par le SHACL de base · `⚙️` = dérivé/calculé, pas une saisie.
 | `healthdcatap:hasCodingSystem` | | `coding` → `CodingSystem` (vocabulaire d'auteur) | |
 | `dpv:hasLegalBasis` | | `legalBasis` → `LegalBasis` (vocabulaire d'auteur) | |
 | `dpv:hasPersonalData` | | `fr.aphp.healthdcat.personalData` → `PersonalData` | |
+| `healthdcatap:hasStructuredData` (`xsd:boolean`, R7 1..1) | | dérivé : `true` ssi ≥1 asset porte un `schemaMetadata` (→ `csvw:Table`) | `model.py::HealthDataset.has_structured_data` ; toujours émis, `false` compris ; validateur HDH indifférent |
 | `foaf:page` | | `institutionalMemory.elements[].url` | non lu en v1 |
 | `dqv:hasQualityAnnotation` | | entités `ASSERTION` | **P2, non implémenté** |
 

--- a/src/dh_healthdcat/mapping/dataset.py
+++ b/src/dh_healthdcat/mapping/dataset.py
@@ -207,6 +207,11 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     for pd in dataset.personal_data:
         graph.add((uri, DPV.hasPersonalData, URIRef(pd)))
 
+    # --- healthdcatap:hasStructuredData (xsd:boolean, cardinalité R7 1..1) :
+    # dérivé de la présence d'un schéma sur au moins un asset (cf.
+    # HealthDataset.has_structured_data) ; toujours émis, `false` compris. ---
+    graph.add((uri, HEALTHDCATAP.hasStructuredData, Literal(dataset.has_structured_data, datatype=XSD.boolean)))
+
     # --- Distributions / échantillons ---
     for distribution in dataset.distributions:
         distribution_mapping.add_distribution(graph, uri, distribution, dataset.title, dataset.issues)

--- a/src/dh_healthdcat/model.py
+++ b/src/dh_healthdcat/model.py
@@ -200,3 +200,11 @@ class HealthDataset:
     @property
     def has_errors(self) -> bool:
         return any(i.severity is Severity.ERROR for i in self.issues)
+
+    @property
+    def has_structured_data(self) -> bool:
+        """healthdcatap:hasStructuredData — `true` ssi au moins un asset
+        (distribution ou échantillon) porte un schéma, c.-à-d. une `Table`
+        dérivée de `schemaMetadata` par le reader."""
+
+        return any(d.table is not None for d in (*self.distributions, *self.samples))

--- a/tests/unit/test_mapping_dataset.py
+++ b/tests/unit/test_mapping_dataset.py
@@ -7,8 +7,11 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
+from rdflib import XSD, Literal
+
 from dh_healthdcat.mapping import vocabularies as v
 from dh_healthdcat.mapping.dataset import dataset_to_graph
+from dh_healthdcat.mapping.namespaces import HEALTHDCATAP
 from dh_healthdcat.model import (
     Agent,
     Column,
@@ -119,6 +122,42 @@ def test_missing_required_fields_are_reported_with_datahub_field_name():
     assert "adms:sample" in by_property
     assert "dct:publisher" in by_property
     assert "healthdcatap:hdab" in by_property
+
+
+def test_has_structured_data_true_when_an_asset_carries_a_schema():
+    """healthdcatap:hasStructuredData (xsd:boolean, 1..1 en R7) se dérive :
+    `true` dès qu'au moins un asset (distribution ou sample) porte un schéma
+    (`csvw:Table` construite depuis `schemaMetadata`)."""
+
+    dataset = _fully_conformant_dataset()  # le sample porte déjà une Table
+    graph = dataset_to_graph(dataset)
+    dataset_uri = next(graph.subjects(HEALTHDCATAP.hasStructuredData, None))
+    values = list(graph.objects(dataset_uri, HEALTHDCATAP.hasStructuredData))
+
+    assert values == [Literal(True, datatype=XSD.boolean)]
+
+
+def test_has_structured_data_false_is_emitted_when_no_asset_carries_a_schema():
+    """La cardinalité R7 est 1..1 : le booléen est toujours émis, `false`
+    compris, quand aucun asset ne porte de schéma."""
+
+    dataset = _fully_conformant_dataset()
+    dataset.samples = (
+        Distribution(
+            node_id=dataset.samples[0].node_id,
+            title=dataset.samples[0].title,
+            is_sample=True,
+            access_url=dataset.samples[0].access_url,
+            source_urn=dataset.samples[0].source_urn,
+        ),
+    )
+    assert all(d.table is None for d in (*dataset.distributions, *dataset.samples))
+
+    graph = dataset_to_graph(dataset)
+    dataset_uri = next(graph.subjects(HEALTHDCATAP.hasStructuredData, None))
+    values = list(graph.objects(dataset_uri, HEALTHDCATAP.hasStructuredData))
+
+    assert values == [Literal(False, datatype=XSD.boolean)]
 
 
 def test_distribution_requires_stricter_fields_than_sample():


### PR DESCRIPTION
Closes #2 — carte wayfinder #1, `consolidation-todo` §C.1.

## Quoi

`healthdcatap:hasStructuredData` (`xsd:boolean`, cardinalité R7 **1..1**) est **dérivé** et **toujours émis** sur le nœud `dcat:Dataset`, `false` compris :

- `HealthDataset.has_structured_data` (`@property`) — `True` ssi ≥ 1 asset (`distributions` ou `samples`) porte une `Table` construite par le `reader` depuis `schemaMetadata`.
- `mapping/dataset.py` émet `Literal(bool, datatype=XSD.boolean)`, inconditionnel.

Le validateur SHACL du HDH n'a aucun chemin pour cette propriété et n'est pas `sh:closed` → émission sans effet sur la conformité.

## Tests

TDD au seam `dataset_to_graph` : branche `true` (asset avec schéma) et branche `false` (aucun schéma, booléen quand même émis). Suite complète au vert (`uv run pytest`).

## Écart R7 résiduel (→ ADR #8)

Le proxy « aspect `schemaMetadata` DataHub avec ≥ 1 champ » est plus étroit que la notion R7 « contient des données structurées ». Un CSV sans `schemaMetadata` enregistré sera émis `false`.