### PR TITLE
feat: Émettre healthdcatap:hasVariables via un csvw:TableGroup

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -59,6 +59,7 @@ vérifié par le SHACL de base · `⚙️` = dérivé/calculé, pas une saisie.
 | `dpv:hasLegalBasis` | | `legalBasis` → `LegalBasis` (vocabulaire d'auteur) | |
 | `dpv:hasPersonalData` | | `fr.aphp.healthdcat.personalData` → `PersonalData` | |
 | `healthdcatap:hasStructuredData` (`xsd:boolean`, R7 1..1) | | dérivé : `true` ssi ≥1 asset porte un `schemaMetadata` (→ `csvw:Table`) | `model.py::HealthDataset.has_structured_data` ; toujours émis, `false` compris ; validateur HDH indifférent |
+| `healthdcatap:hasVariables` → `csvw:TableGroup` (R7, `minCount 1` si `hasStructuredData`) | | ⚙️ regroupe par `csvw:table` toutes les `csvw:Table` du dataset (distributions + samples) | `dataset.py` ; émis ssi ≥1 `csvw:Table` ; nœud `<tablegroup:{uuid}>` ; validateur HDH indifférent (pas de `:CSVWTableGroup_Shape`) |
 | `foaf:page` | | `institutionalMemory.elements[].url` | non lu en v1 |
 | `dqv:hasQualityAnnotation` | | entités `ASSERTION` | **P2, non implémenté** |
 

--- a/src/dh_healthdcat/mapping/dataset.py
+++ b/src/dh_healthdcat/mapping/dataset.py
@@ -24,6 +24,7 @@ from rdflib.namespace import RDFS
 from dh_healthdcat.mapping import agent as agent_mapping
 from dh_healthdcat.mapping import distribution as distribution_mapping
 from dh_healthdcat.mapping.namespaces import (
+    CSVW,
     DCAT,
     DCATAP,
     DCT,
@@ -213,14 +214,31 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     graph.add((uri, HEALTHDCATAP.hasStructuredData, Literal(dataset.has_structured_data, datatype=XSD.boolean)))
 
     # --- Distributions / échantillons ---
+    table_nodes: list[URIRef] = []
     for distribution in dataset.distributions:
-        distribution_mapping.add_distribution(graph, uri, distribution, dataset.title, dataset.issues)
+        _, table_node = distribution_mapping.add_distribution(graph, uri, distribution, dataset.title, dataset.issues)
+        if table_node is not None:
+            table_nodes.append(table_node)
     if not dataset.distributions:
         _missing(dataset, "dcat:distribution", "dataProductProperties.assets (aucun asset non marqué dcat:sample)")
 
     for sample in dataset.samples:
-        distribution_mapping.add_distribution(graph, uri, sample, dataset.title, dataset.issues)
+        _, table_node = distribution_mapping.add_distribution(graph, uri, sample, dataset.title, dataset.issues)
+        if table_node is not None:
+            table_nodes.append(table_node)
     if not dataset.samples:
         _missing(dataset, "adms:sample", "dataProductProperties.assets marqué du tag dcat:sample (aucun trouvé)")
+
+    # --- healthdcatap:hasVariables → csvw:TableGroup (R7) : regroupe par
+    # csvw:table toutes les csvw:Table du dataset. Émis ssi ≥ 1 table (⇔
+    # has_structured_data ; R7 : hasVariables interdit si hasStructuredData
+    # est faux). Le validateur HDH n'a pas de shape TableGroup et
+    # :Dataset_Shape n'est pas sh:closed — émission sans effet sur lui. ---
+    if table_nodes:
+        table_group = node_uri("tablegroup", str(uri))
+        graph.add((uri, HEALTHDCATAP.hasVariables, table_group))
+        graph.add((table_group, RDF.type, CSVW.TableGroup))
+        for table_node in table_nodes:
+            graph.add((table_group, CSVW.table, table_node))
 
     return graph

--- a/src/dh_healthdcat/mapping/distribution.py
+++ b/src/dh_healthdcat/mapping/distribution.py
@@ -42,8 +42,12 @@ def add_distribution(
     distribution: Distribution,
     dataset_name: str,
     issues: list[ValidationIssue],
-) -> URIRef:
-    """Ajoute un dcat:distribution ou adms:sample selon `distribution.is_sample`."""
+) -> tuple[URIRef, URIRef | None]:
+    """Ajoute un dcat:distribution ou adms:sample selon `distribution.is_sample`.
+
+    Renvoie `(nœud distribution, nœud csvw:Table | None)` — l'appelant
+    (`mapping/dataset.py`) collecte les nœuds table pour les regrouper sous le
+    `csvw:TableGroup` porté par `healthdcatap:hasVariables`."""
 
     kind = "sample" if distribution.is_sample else "distribution"
     node = node_uri(kind, distribution.source_urn or distribution.node_id)
@@ -110,10 +114,11 @@ def add_distribution(
         if not distribution.rights:
             _missing(issues, dataset_name, dataset_urn_or_source(distribution), "dct:rights", "fr.aphp.healthdcat.license (DataProduct, hérité)")
 
+    table_node = None
     if distribution.table is not None:
-        _add_table(graph, node, distribution, distribution.table)
+        table_node = _add_table(graph, node, distribution, distribution.table)
 
-    return node
+    return node, table_node
 
 
 def dataset_urn_or_source(distribution: Distribution) -> str:
@@ -123,11 +128,13 @@ def dataset_urn_or_source(distribution: Distribution) -> str:
     return distribution.source_urn
 
 
-def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distribution, table: Table) -> None:
+def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distribution, table: Table) -> URIRef:
     """csvw:Table. Aucun prédicat Distribution→Table n'est défini par les shapes HDH
     (:CSVWTableShape cible juste `csvw:Table` en isolation) ; on relie table et
     distribution par le même `csvw:url` que `dcat:accessURL` plutôt que
-    d'inventer un prédicat."""
+    d'inventer un prédicat. Le rattachement R7 se fait en amont, au niveau
+    `dcat:Dataset` : `mapping/dataset.py` regroupe le nœud renvoyé ici sous un
+    `csvw:TableGroup` porté par `healthdcatap:hasVariables`."""
 
     table_node = node_uri("table", str(distribution_node))
     graph.add((table_node, RDF.type, CSVW.Table))
@@ -148,3 +155,5 @@ def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distributi
         graph.add((column_node, CSVW.datatype, Literal(column.datatype)))
         if column.description:
             graph.add((column_node, DCT.description, Literal(column.description, lang="fr")))
+
+    return table_node

--- a/tests/unit/test_mapping_dataset.py
+++ b/tests/unit/test_mapping_dataset.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from rdflib import XSD, Literal
+from rdflib import RDF, XSD, Literal
 
 from dh_healthdcat.mapping import vocabularies as v
 from dh_healthdcat.mapping.dataset import dataset_to_graph
-from dh_healthdcat.mapping.namespaces import HEALTHDCATAP
+from dh_healthdcat.mapping.namespaces import CSVW, HEALTHDCATAP
 from dh_healthdcat.model import (
     Agent,
     Column,
@@ -158,6 +158,47 @@ def test_has_structured_data_false_is_emitted_when_no_asset_carries_a_schema():
     values = list(graph.objects(dataset_uri, HEALTHDCATAP.hasStructuredData))
 
     assert values == [Literal(False, datatype=XSD.boolean)]
+
+
+def test_has_variables_groups_every_csvw_table_under_one_tablegroup():
+    """healthdcatap:hasVariables → csvw:TableGroup au niveau du dcat:Dataset,
+    regroupant par csvw:table toutes les csvw:Table déjà produites depuis
+    schemaMetadata (distributions comme échantillons)."""
+
+    dataset = _fully_conformant_dataset()  # 1 csvw:Table, portée par le sample
+    graph = dataset_to_graph(dataset)
+
+    dataset_uri = next(graph.subjects(HEALTHDCATAP.hasVariables, None))
+    groups = list(graph.objects(dataset_uri, HEALTHDCATAP.hasVariables))
+    assert len(groups) == 1
+    table_group = groups[0]
+    assert (table_group, RDF.type, CSVW.TableGroup) in graph
+
+    grouped = set(graph.objects(table_group, CSVW.table))
+    all_tables = set(graph.subjects(RDF.type, CSVW.Table))
+    assert grouped == all_tables
+    assert len(grouped) == 1
+
+
+def test_no_tablegroup_when_no_asset_carries_a_schema():
+    """R7 interdit healthdcatap:hasVariables quand hasStructuredData est faux :
+    aucune table → aucun csvw:TableGroup, aucun hasVariables."""
+
+    dataset = _fully_conformant_dataset()
+    dataset.samples = (
+        Distribution(
+            node_id=dataset.samples[0].node_id,
+            title=dataset.samples[0].title,
+            is_sample=True,
+            access_url=dataset.samples[0].access_url,
+            source_urn=dataset.samples[0].source_urn,
+        ),
+    )
+
+    graph = dataset_to_graph(dataset)
+
+    assert list(graph.objects(None, HEALTHDCATAP.hasVariables)) == []
+    assert list(graph.subjects(RDF.type, CSVW.TableGroup)) == []
 
 
 def test_distribution_requires_stricter_fields_than_sample():


### PR DESCRIPTION
Closes #3 — carte wayfinder #1, `consolidation-todo` §C.2.

**PR empilée** sur #9 (`feat/hasstructureddata-emission`). Cible cette branche ; à rebaser sur `main` après merge de #9.

## Quoi

`dcat:Dataset —healthdcatap:hasVariables→ csvw:TableGroup —csvw:table→` chaque `csvw:Table` du dataset (distributions **et** échantillons).

- Émis **ssi** ≥ 1 `csvw:Table` — soit exactement `has_structured_data`. R7 interdit `hasVariables` quand `hasStructuredData = false`.
- `add_distribution` renvoie désormais `(nœud distribution, nœud csvw:Table | None)` (les deux appelants ignoraient sa valeur de retour) ; `dataset.py` collecte les nœuds table et construit le groupe.
- `_add_table` inchangé (garde `csvw:url`, exigé par `:CSVWTableShape`).

Validateur HDH indifférent : ni chemin `hasVariables` ni `:CSVWTableGroup_Shape`, `:Dataset_Shape` non `sh:closed`. `pyshacl` vert.

## Tests

TDD au seam `dataset_to_graph` : (1) toutes les `csvw:Table` sous un unique `csvw:TableGroup` ; (2) aucune table → ni `hasVariables` ni `TableGroup`.

## Écarts R7 résiduels (→ ADR #8)

1. Le sous-arbre `csvw:TableGroup → csvw:table → csvw:Table → csvw:Column` n'est vérifié par aucun validateur (HDH cible `csvw:Table`/`csvw:Column` en isolation ; R7 hors CI).
2. `_add_table` n'émet `dct:description` sur une `csvw:Column` que si la colonne en porte une, alors que `:CSVWColumnShape` (R7) l'exige `minCount 1` par colonne. Pré-existant, désormais atteignable via `hasVariables`.