### PR TITLE
feat: Résoudre referenceSpecification via un vocab d'URIs canoniques

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -49,7 +49,7 @@ vérifié par le SHACL de base · `⚙️` = dérivé/calculé, pas une saisie.
 | `dct:modified` | | `dataProductProperties.lastModified` | |
 | `dct:temporal` | | `temporalCoverageStart`/`End` | |
 | `dct:accrualPeriodicity` | | `publishingFrequency` → `Frequency` | |
-| `dct:conformsTo` | | `referenceSpecification`, enveloppé en URI si nécessaire | |
+| `dct:conformsTo` | | `referenceSpecification` → `ReferenceSpecification` (vocab d'auteur) ; code hors vocab → `urn:aphp:conformsTo:<code>` (ex. `OSIRIS`) | |
 | `dct:license` | | `license`, passage direct | |
 | `dct:isReferencedBy` | | `fr.aphp.healthdcat.isReferencedBy` | |
 | `healthdcatap:numberOfRecords`/`numberOfUniqueIndividuals`/`min|maxTypicalAge` | | `number` | |
@@ -100,7 +100,7 @@ valide avec la seule `dcat:accessURL`.
 
 12 fichiers vendus tels quels depuis
 `hdh/.../controlled_vocabulary/controled_voc_dicts/` (voir `vocab/README.md`
-pour la liste et la procédure de resynchronisation), plus deux fichiers
+pour la liste et la procédure de resynchronisation), plus trois fichiers
 d'auteur :
 
 - **`LegalBasis.yml`** — mapping des 12 codes `eu-gdpr:A6-1-*`/`eu-gdpr:A9-2-*`
@@ -109,6 +109,10 @@ d'auteur :
   (SNOMED-CT, LOINC, ICD-10/11, ATC : URIs canoniques stables ; CIP13, UCD,
   CCAM, NFS : espace de noms `https://aphp.fr/codesystem/*` local et
   explicitement non déréférençable, faute d'identifiant officiel ANS/HDH).
+- **`ReferenceSpecification.yml`** — `HL7-FHIR-R4` → `http://hl7.org/fhir/4.0.1`,
+  `OMOP-CDM-5.4` → page GitHub Pages OHDSI versionnée, `HL7v2` → `urn:hl7-org:v2xml`
+  (URIs vérifiées le 2026-08-28, cf. `docs/research/reference-specification-uris.md`).
+  Câblé dans `reader/dataproduct.py` ; code hors vocab → `urn:aphp:conformsTo:<code>`.
 
 Toute résolution échoue explicitement (`UnknownVocabularyValueError`) plutôt
 que de retomber sur un `skos:prefLabel "NA"@en` silencieux comme le fait le

--- a/docs/research/reference-specification-uris.md
+++ b/docs/research/reference-specification-uris.md
@@ -1,0 +1,131 @@
+# URIs canoniques des standards de référence (`dct:conformsTo`)
+
+Recherche préalable à la création de
+`src/dh_healthdcat/mapping/vocab/ReferenceSpecification.yml`, qui doit mapper les
+`allowedValues` de la structured property `fr.aphp.healthdcat.referenceSpecification`
+(registre : `input/structured-property/hdcat-provenance/referencespecification.yml`)
+vers de vraies IRI. Sans ce vocab, l'exporteur produit `URIRef("HL7-FHIR-R4")`,
+c'est-à-dire une IRI relative invalide (cf.
+`datahub-data-gov-registry/docs/research/healthdcat-ap-sp-file-audit.md`).
+
+Périmètre : `HL7-FHIR-R4`, `OMOP-CDM-5.4`, `HL7v2`. `OSIRIS` **reste hors périmètre**
+et conserve son enveloppe `urn:aphp:conformsTo:OSIRIS` (pas d'URI publique stable).
+
+Vérifié le 2026-08-28 contre les sources primaires listées.
+
+## Rappel du besoin
+
+`referenceSpecification` → `dct:conformsTo` (le terme AP-HP `healthdcat:referenceSpecification`
+n'existe pas dans HealthDCAT-AP ; `dct:conformsTo` est la propriété du profil, applicable
+au `dcat:Dataset` **et** à la `dcat:Distribution`). La valeur attendue est une IRI
+désignant un `dct:Standard`. Le SHACL du HDH n'impose qu'un `sh:nodeKind sh:BlankNodeOrIRI`
+sans `sh:in` : n'importe quelle IRI passe la validation, mais on veut une IRI *signifiante
+et stable*.
+
+Le registre (`datahub-data-gov-registry`) ne modélise nulle part `dct:conformsTo` avec des
+URI réelles : l'ADR 0005 et `docs/research/consolidation-todo.md` renvoient explicitement
+la construction de ce vocab à l'exporteur (« A canonical-URI vocabulary for
+`referenceSpecification`'s four values is a further exporter-side follow-up »). Aucun
+précédent interne à recopier, donc ; ce document tient lieu de justification.
+
+## HL7-FHIR-R4
+
+**URI canonique retenue : `http://hl7.org/fhir/4.0.1`** (versionnée, schéma `http://`).
+
+- HL7 identifie la release R4 par le numéro de version **`4.0.1`** (« publication.major.minor.revision »,
+  4 = Release 4, correction technique n°1 du 2019-11-01). C'est l'identifiant que HL7
+  utilise lui-même comme canonique de version pour le paquet cœur `hl7.fhir.r4.core#4.0.1`
+  et comme code du CodeSystem `http://hl7.org/fhir/FHIR-version`.
+  Source : <https://hl7.org/fhir/R4/versions.html>.
+- Les canoniques HL7 FHIR sont déclarés avec le schéma **`http://`** par convention (même
+  si le contenu est servi en `https://`). On aligne donc `ReferenceSpecification.yml` sur
+  `http://` — cohérent avec `CodingSystem.yml` du même dépôt (`http://hl7.org/fhir/sid/icd-10`,
+  `http://loinc.org`).
+- **Forme : épingler la version.** `dct:conformsTo` doit désigner un standard précis.
+  - `http://hl7.org/fhir/4.0.1` est non ambigu.
+  - `http://hl7.org/fhir/R4` est une **étiquette de release** mouvante (R4 a d'abord été
+    4.0.0, puis 4.0.1 après correction technique). À éviter comme *valeur* de conformité.
+- **Forme résolvable :** `https://hl7.org/fhir/R4/` est le « permanent home » de la spec R4
+  (« will always be available at this URL »). `http://hl7.org/fhir/R4` **et**
+  `http://hl7.org/fhir/4.0.1` redirigent tous deux vers `hl7.org/fhir/R4/index.html`
+  (vérifié). L'URI canonique retenue est donc *aussi* déréférençable en pratique — bonus,
+  pas une exigence.
+  Sources : <https://hl7.org/fhir/R4/index.html>, <http://hl7.org/fhir/R4>, <http://hl7.org/fhir/4.0.1>.
+- Option : exposer en plus `https://hl7.org/fhir/R4/` via `foaf:page`/`rdfs:seeAlso` pour
+  le lecteur humain, mais la valeur de `dct:conformsTo` = `http://hl7.org/fhir/4.0.1`.
+
+## OMOP-CDM-5.4
+
+**URI canonique retenue : `https://ohdsi.github.io/CommonDataModel/cdm54.html`**
+(versionnée dans le chemin, schéma `https://` natif).
+
+- **Il n'existe pas d'URI abstraite façon HL7** pour l'OMOP CDM. OHDSI ne publie pas de
+  registre d'IRI ni de namespace canonique : la spécification est un site GitHub Pages.
+- La page **v5.4** officielle est `https://ohdsi.github.io/CommonDataModel/cdm54.html`
+  (« This is the specification document for the OMOP Common Data Model, v5.4 » — description
+  haut niveau, conventions ETL, contraintes par table/champ). C'est l'artefact le plus
+  autoritatif et le plus stable qu'OHDSI propose pour cette version.
+  Sources : <https://ohdsi.github.io/CommonDataModel/cdm54.html>,
+  <https://ohdsi.github.io/CommonDataModel/> (index des versions du CDM).
+- **Forme : version épinglée, résolvable.** Le `5.4` est porté par le segment `cdm54`
+  du chemin. `https://` d'origine.
+- **Alternatives** (non retenues, à documenter) :
+  - `https://github.com/OHDSI/CommonDataModel/tree/v5.4.0` — tag de release immuable
+    (DDL 5.4 figées). À préférer *seulement* si on veut une immutabilité stricte au
+    patch près. Source : <https://github.com/OHDSI/CommonDataModel/releases>.
+  - `https://ohdsi.github.io/CommonDataModel/` — sans version, trop imprécis pour
+    `dct:conformsTo`.
+- **Ambiguïté mineure :** la ligne 5.4 a des points de version (`v5.4.0`, `v5.4.1`). Le code
+  `OMOP-CDM-5.4` vise la *minor line* 5.4 ; `cdm54.html` suit cette ligne — cohérent avec
+  l'intention du code. Pas de DOI Zenodo officiel pour le paquet `CommonDataModel` (recherché,
+  rien trouvé).
+
+## HL7v2
+
+**Pas d'URI canonique unique — c'est un fait à assumer et à écrire tel quel.**
+HL7 v2 est une **famille** de versions (2.1 … 2.9.1) ; le code `HL7v2` est
+délibérément non versionné, et HL7 ne définit aucune IRI « le standard v2 » façon
+`http://hl7.org/fhir/...`.
+
+**Meilleure option disponible retenue : `urn:hl7-org:v2xml`.**
+
+- C'est le **namespace XML officiel** des messages HL7 v2 (schémas v2.x XML : `urn:hl7-org:v2xml`
+  y est à la fois *default* et *target namespace* ; les parseurs l'exigent). Identifiant réel,
+  détenu par HL7, stable depuis ~20 ans. **Non déréférençable** (URN), comme les entrées
+  placeholder assumées de `CodingSystem.yml` (`https://aphp.fr/codesystem/...`).
+  Source : schémas HL7 v2.x Messaging Schemas — product brief
+  <https://www.hl7.org/implement/standards/product_brief.cfm?product_id=213> ; usage
+  documenté p. ex. HAPI HL7v2, BizTalk Accelerator for HL7.
+- **Forme résolvable, humaine :** `https://www.hl7.org/implement/standards/product_brief.cfm?product_id=185`
+  (« HL7 Version 2 Product Suite »). `https://`, mais URL à query-string — fragile, mauvais
+  *identifiant*. À réserver à `foaf:page`, pas à la valeur de `dct:conformsTo`.
+  Source : <https://www.hl7.org/implement/standards/product_brief.cfm?product_id=185>.
+- **Choix pragmatique, pas un canonique normatif.** `urn:hl7-org:v2xml` porte à l'origine
+  la sémantique « encodage XML des messages v2 », pas « conformité générique au standard v2 ».
+  On l'accepte faute de mieux dans l'écosystème HL7.
+- **Repli acceptable** si l'équipe refuse cette surcharge sémantique : garder
+  `urn:aphp:conformsTo:HL7v2` (même traitement qu'`OSIRIS`). À trancher à l'implémentation
+  du vocab ; recommandation de cette recherche = `urn:hl7-org:v2xml`.
+
+## Tableau de recommandation
+
+| Code | URI canonique | Forme | Source primaire |
+|---|---|---|---|
+| `HL7-FHIR-R4` | `http://hl7.org/fhir/4.0.1` | Versionnée (`4.0.1`, pas `R4`) ; schéma `http://` par convention HL7 ; résolvable de fait (redirige vers `hl7.org/fhir/R4/`) | HL7 FHIR, <https://hl7.org/fhir/R4/versions.html> + <http://hl7.org/fhir/4.0.1> |
+| `OMOP-CDM-5.4` | `https://ohdsi.github.io/CommonDataModel/cdm54.html` | Version épinglée dans le chemin (`cdm54`) ; `https://` natif ; résolvable ; pas d'IRI abstraite existante | OHDSI, <https://ohdsi.github.io/CommonDataModel/cdm54.html> |
+| `HL7v2` | `urn:hl7-org:v2xml` | **Pas de canonique unique** ; namespace XML HL7 v2, non versionné, non déréférençable ; page humaine `product_id=185` en `foaf:page` | Schémas HL7 v2.x XML ; <https://www.hl7.org/implement/standards/product_brief.cfm?product_id=213> et `?product_id=185` |
+| `OSIRIS` | *(hors périmètre)* `urn:aphp:conformsTo:OSIRIS` | URN AP-HP local, pas d'URI publique stable | — |
+
+## Impact sur `ReferenceSpecification.yml`
+
+- Fichier **d'auteur** (pas vendu du HDH), à ranger comme `LegalBasis.yml` /
+  `CodingSystem.yml` : en-tête de commentaire expliquant l'origine des URI et le statut
+  de `HL7v2` (choix pragmatique) et d'`OSIRIS` (URN local conservé).
+- `vocabulary_list` : les 3 codes → URI ci-dessus. Décider si `OSIRIS` est dans le vocab
+  avec son `urn:aphp:*` ou laissé au fallback `_as_uri(..., "aphp:conformsTo")` de
+  `reader/dataproduct.py` (qui enveloppe déjà tout code non-URI en `urn:aphp:conformsTo:<code>`).
+- `reader/dataproduct.py` : `_as_uri` laisse passer une valeur qui est déjà une URI
+  (`http://` / `https://` / `urn:`). Résoudre le code via le vocab **avant** `_as_uri`
+  suffit ; aucune modif de `_as_uri` nécessaire.
+- Revalider si : FHIR publie une nouvelle correction technique R4 (peu probable, R4 gelée) ;
+  OHDSI réorganise le site CommonDataModel ; l'équipe tranche le repli `urn:aphp:*` pour `HL7v2`.

--- a/src/dh_healthdcat/mapping/vocab/README.md
+++ b/src/dh_healthdcat/mapping/vocab/README.md
@@ -25,9 +25,20 @@ autorisées), donc l'hôte exact ne fait pas échouer la validation. Si le HDH
 republie un jour ces dictionnaires sur un hôte de production, un simple
 resynchronisation de ces deux fichiers suffit — voir la politique ci-dessus.
 
-`LegalBasis.yml` est le seul fichier d'auteur (pas vendu) : il documente le
-mapping des 12 codes `A6-1-*`/`A9-2-*` de la structured property
-`fr.aphp.healthdcat.legalBasis` vers l'extension GDPR du Data Privacy
-Vocabulary (`https://w3id.org/dpv/legal/eu/gdpr#`). Les 12 identifiants ont été
-vérifiés terme à terme contre cette source le 2026-08-14 ; à revalider si le
-DPV publie une nouvelle version majeure.
+Trois fichiers sont d'auteur (pas vendus du HDH, qui ne publie pas de
+dictionnaire équivalent) :
+
+- `LegalBasis.yml` : mapping des 12 codes `A6-1-*`/`A9-2-*` de
+  `fr.aphp.healthdcat.legalBasis` vers l'extension GDPR du Data Privacy
+  Vocabulary (`https://w3id.org/dpv/legal/eu/gdpr#`). Les 12 identifiants ont
+  été vérifiés terme à terme contre cette source le 2026-08-14 ; à revalider si
+  le DPV publie une nouvelle version majeure.
+- `CodingSystem.yml` : les 9 codes de `fr.aphp.healthdcat.coding` (URIs
+  canoniques HL7/OMS/WHO-CC stables ; `CIP13`/`UCD`/`CCAM`/`NFS` en espace de
+  noms AP-HP local non déréférençable, faute d'identifiant officiel ANS/HDH).
+- `ReferenceSpecification.yml` : `HL7-FHIR-R4` / `OMOP-CDM-5.4` / `HL7v2` de
+  `fr.aphp.healthdcat.referenceSpecification` (→ `dct:conformsTo`) vers leurs
+  URIs canoniques, vérifiées contre les sources primaires le 2026-08-28 (voir
+  `docs/research/reference-specification-uris.md`). Tout autre code (p. ex.
+  `OSIRIS`) retombe sur `urn:aphp:conformsTo:<code>` côté
+  `reader/dataproduct.py`.

--- a/src/dh_healthdcat/mapping/vocab/ReferenceSpecification.yml
+++ b/src/dh_healthdcat/mapping/vocab/ReferenceSpecification.yml
@@ -1,0 +1,24 @@
+# Vocabulaire d'auteur (dh-healthdcat), pas vendu du HDH — le HDH ne publie pas
+# de dictionnaire "spécifications de référence" parmi ses vocabulaires contrôlés.
+#
+# Couvre les valeurs de `fr.aphp.healthdcat.referenceSpecification` (→ dct:conformsTo).
+# URIs canoniques vérifiées le 2026-08-28 contre les sources primaires — voir
+# `docs/research/reference-specification-uris.md`. Choix de forme :
+#   - HL7-FHIR-R4 : version épinglée `4.0.1` (et non l'étiquette mouvante "R4"),
+#     schéma `http://` par convention HL7 (cohérent avec CodingSystem.yml).
+#   - OMOP-CDM-5.4 : page GitHub Pages versionnée d'OHDSI — aucune IRI abstraite
+#     façon HL7 n'existe pour l'OMOP CDM.
+#   - HL7v2 : `urn:hl7-org:v2xml`, namespace XML officiel HL7 v2 (URN réel,
+#     stable, non déréférençable) — v2 est une famille de versions sans URI
+#     canonique unique.
+# Tout code absent d'ici (p. ex. OSIRIS) retombe sur `urn:aphp:conformsTo:<code>`
+# côté reader/dataproduct.py — comportement voulu, pas un oubli.
+ReferenceSpecification:
+  vocabulary_list:
+    HL7-FHIR-R4: "http://hl7.org/fhir/4.0.1"
+    OMOP-CDM-5.4: "https://ohdsi.github.io/CommonDataModel/cdm54.html"
+    HL7v2: "urn:hl7-org:v2xml"
+  fr:
+    HL7-FHIR-R4: "HL7 FHIR (Release 4, v4.0.1)"
+    OMOP-CDM-5.4: "OMOP Common Data Model v5.4"
+    HL7v2: "HL7 version 2.x (messagerie)"

--- a/src/dh_healthdcat/mapping/vocabularies.py
+++ b/src/dh_healthdcat/mapping/vocabularies.py
@@ -95,6 +95,7 @@ LANGUAGE = _load("PublicationsEuropAuthorityLanguage")
 COUNTRY = _load("PublicationsEuropAuthorityCountry")
 LEGAL_BASIS = _load("LegalBasis")
 CODING_SYSTEM = _load("CodingSystem")
+REFERENCE_SPECIFICATION = _load("ReferenceSpecification")
 
 # dcat:theme n'a pas de dictionnaire dédié côté HDH (PublicationsEuropAuthorityTheme
 # existe mais sert au thème générique EU) ; HealthDCAT-AP impose la valeur HEAL a

--- a/src/dh_healthdcat/reader/dataproduct.py
+++ b/src/dh_healthdcat/reader/dataproduct.py
@@ -199,10 +199,14 @@ def read_data_product(
         except UnknownVocabularyValueError:
             spatial.append(code)  # déjà une URI d'un autre référentiel (GeoNames...) ou code régional (FR-75)
 
-    conforms_to = tuple(
-        _as_uri(c, "aphp:conformsTo")
-        for c in props.get_strings(ctx, entity, "fr.aphp.healthdcat.referenceSpecification", title, dataproduct_urn, issues)
-    )
+    conforms_to: list[str] = []
+    for code in props.get_strings(ctx, entity, "fr.aphp.healthdcat.referenceSpecification", title, dataproduct_urn, issues):
+        try:
+            conforms_to.append(v.REFERENCE_SPECIFICATION.resolve(code))
+        except UnknownVocabularyValueError:
+            fallback = _as_uri(code, "aphp:conformsTo")  # OSIRIS & co. → urn:aphp:conformsTo:<code>
+            if fallback:
+                conforms_to.append(fallback)
     license_ = props.get_string(ctx, entity, "fr.aphp.healthdcat.license", title, dataproduct_urn, issues)
     is_referenced_by = props.get_strings(ctx, entity, "fr.aphp.healthdcat.isReferencedBy", title, dataproduct_urn, issues)
 

--- a/tests/fixtures/fake_datahub.py
+++ b/tests/fixtures/fake_datahub.py
@@ -73,6 +73,8 @@ def _entities() -> dict[str, dict]:
                     _sp("fr.aphp.healthdcat.contactPointEmail", "eds-coord@aphp.fr"),
                     _sp("fr.aphp.healthdcat.contactPointUrl", "https://eds.aphp.fr"),
                     _sp("fr.aphp.healthdcat.license", "https://eds.aphp.fr/licence"),
+                    # referenceSpecification : un code du vocab + un code local (OSIRIS)
+                    _sp("fr.aphp.healthdcat.referenceSpecification", "HL7-FHIR-R4", "OSIRIS"),
                     _sp("fr.aphp.healthdcat.numberOfRecords", "1000000000"),  # string au lieu de number : coercition
                     _sp("fr.aphp.healthdcat.publishingFrequency", "DAILY"),
                     _sp(UNDECLARED_PROPERTY, "x"),
@@ -169,6 +171,7 @@ _DECLARED_QUALIFIED_NAMES = [
     "fr.aphp.healthdcat.provenance", "fr.aphp.healthdcat.purpose", "fr.aphp.healthdcat.contactPointName",
     "fr.aphp.healthdcat.contactPointEmail", "fr.aphp.healthdcat.contactPointUrl", "fr.aphp.healthdcat.license",
     "fr.aphp.healthdcat.numberOfRecords", "fr.aphp.healthdcat.publishingFrequency", "fr.aphp.healthdcat.accessUrl",
+    "fr.aphp.healthdcat.referenceSpecification",
     "fr.aphp.healthdcat.publisherName", "fr.aphp.healthdcat.publisherHomepage", "fr.aphp.healthdcat.publisherEmail",
     "fr.aphp.healthdcat.publisherType", "fr.aphp.healthdcat.publisherNote", "fr.aphp.healthdcat.trustedDataHolder",
     "fr.aphp.healthdcat.hdabName", "fr.aphp.healthdcat.hdabHomepage", "fr.aphp.healthdcat.hdabEmail",

--- a/tests/unit/test_reader_dataproduct.py
+++ b/tests/unit/test_reader_dataproduct.py
@@ -27,6 +27,21 @@ def test_read_data_product_end_to_end():
     assert dataset.samples[0].source_urn == SAMPLE_URN
 
 
+def test_reference_specification_codes_resolve_to_canonical_uris_local_fallback_kept():
+    """`fr.aphp.healthdcat.referenceSpecification` : les codes du vocab
+    ReferenceSpecification deviennent leur URI canonique ; un code hors vocab
+    (OSIRIS) retombe silencieusement sur urn:aphp:conformsTo:<code>."""
+
+    ctx = build_context()
+    dataset = read_data_product(ctx, DATAPRODUCT_URN)
+
+    assert dataset.conforms_to == (
+        "http://hl7.org/fhir/4.0.1",
+        "urn:aphp:conformsTo:OSIRIS",
+    )
+    assert not [i for i in dataset.issues if i.datahub_field == "fr.aphp.healthdcat.referenceSpecification"]
+
+
 def test_type_coercion_warns_but_does_not_fail():
     ctx = build_context()
     dataset = read_data_product(ctx, DATAPRODUCT_URN)

--- a/tests/unit/test_vocabularies.py
+++ b/tests/unit/test_vocabularies.py
@@ -39,6 +39,18 @@ def test_legal_basis_matches_dpv_gdpr_extension():
     assert v.LEGAL_BASIS.resolve("eu-gdpr:A9-2-j") == "https://w3id.org/dpv/legal/eu/gdpr#A9-2-j"
 
 
+def test_reference_specification_maps_standards_to_canonical_uris():
+    # Vocabulaire d'auteur (pas vendu du HDH) — URIs canoniques vérifiées le
+    # 2026-08-28 contre les sources primaires (voir docs/research/
+    # reference-specification-uris.md). OSIRIS n'y figure pas : il retombe sur
+    # urn:aphp:conformsTo:OSIRIS côté reader.
+    assert v.REFERENCE_SPECIFICATION.resolve("HL7-FHIR-R4") == "http://hl7.org/fhir/4.0.1"
+    assert v.REFERENCE_SPECIFICATION.resolve("OMOP-CDM-5.4") == "https://ohdsi.github.io/CommonDataModel/cdm54.html"
+    assert v.REFERENCE_SPECIFICATION.resolve("HL7v2") == "urn:hl7-org:v2xml"
+    with pytest.raises(v.UnknownVocabularyValueError):
+        v.REFERENCE_SPECIFICATION.resolve("OSIRIS")
+
+
 def test_health_category_and_theme_use_hdh_dev_host():
     # Question ouverte Q1 de la spec : ne pas "corriger" cette URI par erreur.
     assert v.HEALTH_CATEGORY.resolve("HRAD").startswith("http://13.81.34.152:1101/")


### PR DESCRIPTION
Closes #5 — carte wayfinder #1, `consolidation-todo` §C.3. URIs issues du ticket research #4.

## Quoi

Nouveau vocab d''auteur `src/dh_healthdcat/mapping/vocab/ReferenceSpecification.yml` :

| Code | URI |
|---|---|
| `HL7-FHIR-R4` | `http://hl7.org/fhir/4.0.1` (version épinglée, pas l''étiquette mouvante `R4`) |
| `OMOP-CDM-5.4` | `https://ohdsi.github.io/CommonDataModel/cdm54.html` (page OHDSI versionnée — aucune IRI abstraite n''existe) |
| `HL7v2` | `urn:hl7-org:v2xml` (namespace XML officiel HL7 v2 ; v2 est une famille sans URI canonique unique) |

Câblé dans `reader/dataproduct.py` : le code est résolu via le vocab **avant** `_as_uri`. Tout code hors vocab — `OSIRIS`, ou un futur code non mappé — retombe **silencieusement** sur `urn:aphp:conformsTo:<code>`, comme le traitement de `spatialCoverage`. `_as_uri` inchangé.

## Tests

- `test_vocabularies.py` : contenu du vocab (3 URIs + `OSIRIS` lève `UnknownVocabularyValueError`).
- `test_reader_dataproduct.py` : end-to-end via `read_data_product` — `conforms_to == ("http://hl7.org/fhir/4.0.1", "urn:aphp:conformsTo:OSIRIS")`, aucun warning. Fixture `fake_datahub.py` étendue (`referenceSpecification` + déclaration référentiel).

`uv run pytest` : 102 au vert. `dct:conformsTo` reste `sh:BlankNodeOrIRI` → conformité `pyshacl` inchangée.

## Notes

- Contient aussi `docs/research/reference-specification-uris.md` (findings du ticket #4, cherry-pické depuis `research/reference-specification-uris` — la branche jetable peut être supprimée après merge).
- Indépendante de #10 (`hasVariables`). Conflit trivial possible sur `docs/mapping.md` selon l''ordre de merge #10 / celle-ci.