### PR TITLE
chore: Repointer HealthCategories/HealthTheme sur le namespace SEMIC

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -142,5 +142,5 @@ détail exact.
 | `prov:qualifiedAttribution` (dataController/dataProcessor) | Propriétés existantes non reprises, pas d'équivalent HealthDCAT-AP direct | P2 |
 | `dqv:hasQualityAnnotation` | Entités `ASSERTION` (quality-layer) non lues | P2 |
 | `fr.aphp.healthdcat.publishingFrequency` allowedValue `IRREGULAR` | Le vocabulaire HDH `Frequency` attend `IRREG` — écart détecté par `resolve_or_warn` (dégradé en avertissement, pas d'échec) | à corriger dans `assets.yml` |
-| `HealthCategories`/`HealthTheme` (URIs HDH) | Pointent sur un hôte de développement en dur (`http://13.81.34.152:1101/...`) côté HDH | à reconfirmer avant publication en production |
+| `HealthCategories`/`HealthTheme` (URIs) | Repointées de l'hôte de dév en dur (`13.81.34.152:1101`) vers le namespace SEMIC `http://healthdataportal.eu/resource/authority/...` (issue #6). Aucun hôte canonique publié à ce jour → IRI pas encore déréférençables | resynchroniser quand l'EC/HDH publiera le vocabulaire officiel |
 | `fr.aphp.healthdcat.retentionPeriod` (ancienne, texte ISO 8601) | Dépréciée au profit de `retentionPeriodStart`/`retentionPeriodEnd`, toujours déclarée dans `assets.yml` mais plus exportée | à retirer une fois la curation terminée |

--- a/src/dh_healthdcat/mapping/vocab/HealthCategories.yml
+++ b/src/dh_healthdcat/mapping/vocab/HealthCategories.yml
@@ -1,23 +1,23 @@
 HealthCategories:
   col: A
   vocabulary_list:
-    EHRS: http://13.81.34.152:1101/resource/authority/healthcategories/EHRS
-    DIOH: http://13.81.34.152:1101/resource/authority/healthcategories/DIOH
-    NRPE: http://13.81.34.152:1101/resource/authority/healthcategories/NRPE
-    RPDG: http://13.81.34.152:1101/resource/authority/healthcategories/RPDG
-    HRAD: http://13.81.34.152:1101/resource/authority/healthcategories/HRAD
-    HGPD: http://13.81.34.152:1101/resource/authority/healthcategories/HGPD
-    HPML: http://13.81.34.152:1101/resource/authority/healthcategories/HPML
-    PGEH: http://13.81.34.152:1101/resource/authority/healthcategories/PGEH
-    WELA: http://13.81.34.152:1101/resource/authority/healthcategories/WELA
-    IDHP: http://13.81.34.152:1101/resource/authority/healthcategories/IDHP
-    PHDR: http://13.81.34.152:1101/resource/authority/healthcategories/PHDR
-    MRMR: http://13.81.34.152:1101/resource/authority/healthcategories/MRMR
-    EHCT: http://13.81.34.152:1101/resource/authority/healthcategories/EHCT
-    EMRD: http://13.81.34.152:1101/resource/authority/healthcategories/EMRD
-    RMMD: http://13.81.34.152:1101/resource/authority/healthcategories/RMMD
-    RQSH: http://13.81.34.152:1101/resource/authority/healthcategories/RQSH
-    EINS: http://13.81.34.152:1101/resource/authority/healthcategories/EINS
+    EHRS: http://healthdataportal.eu/resource/authority/healthcategories/EHRS
+    DIOH: http://healthdataportal.eu/resource/authority/healthcategories/DIOH
+    NRPE: http://healthdataportal.eu/resource/authority/healthcategories/NRPE
+    RPDG: http://healthdataportal.eu/resource/authority/healthcategories/RPDG
+    HRAD: http://healthdataportal.eu/resource/authority/healthcategories/HRAD
+    HGPD: http://healthdataportal.eu/resource/authority/healthcategories/HGPD
+    HPML: http://healthdataportal.eu/resource/authority/healthcategories/HPML
+    PGEH: http://healthdataportal.eu/resource/authority/healthcategories/PGEH
+    WELA: http://healthdataportal.eu/resource/authority/healthcategories/WELA
+    IDHP: http://healthdataportal.eu/resource/authority/healthcategories/IDHP
+    PHDR: http://healthdataportal.eu/resource/authority/healthcategories/PHDR
+    MRMR: http://healthdataportal.eu/resource/authority/healthcategories/MRMR
+    EHCT: http://healthdataportal.eu/resource/authority/healthcategories/EHCT
+    EMRD: http://healthdataportal.eu/resource/authority/healthcategories/EMRD
+    RMMD: http://healthdataportal.eu/resource/authority/healthcategories/RMMD
+    RQSH: http://healthdataportal.eu/resource/authority/healthcategories/RQSH
+    EINS: http://healthdataportal.eu/resource/authority/healthcategories/EINS
   en:
     EHRS: Electronic Health Data from EHRs
     DIOH: Data on factors impacting on health, including socio-economic, environmental

--- a/src/dh_healthdcat/mapping/vocab/HealthTheme.yml
+++ b/src/dh_healthdcat/mapping/vocab/HealthTheme.yml
@@ -1,26 +1,26 @@
 HealthTheme:
   col: A
   vocabulary_list:
-    climate_health: http://13.81.34.152:1101/resource/authority/health-theme/CLIMATE_HEALTH
-    antimicrobial_control: http://13.81.34.152:1101/resource/authority/health-theme/ANTIMICROBIAL_CONTROL
-    environmental_health: http://13.81.34.152:1101/resource/authority/health-theme/ENVIRONMENTAL_HEALTH
-    blood_infections: http://13.81.34.152:1101/resource/authority/health-theme/BLOOD_INFECTIONS
-    health_systems: http://13.81.34.152:1101/resource/authority/health-theme/HEALTH_SYSTEMS
-    sensory_health: http://13.81.34.152:1101/resource/authority/health-theme/SENSORY_HEALTH
-    respiratory_diseases: http://13.81.34.152:1101/resource/authority/health-theme/RESPIRATORY_DISEASES
-    lifecourse_health: http://13.81.34.152:1101/resource/authority/health-theme/LIFECOURSE_HEALTH
-    immunization_diseases: http://13.81.34.152:1101/resource/authority/health-theme/IMMUNIZATION_DISEASES
-    enteric_infections: http://13.81.34.152:1101/resource/authority/health-theme/ENTERIC_INFECTIONS
-    injury_prevention: http://13.81.34.152:1101/resource/authority/health-theme/INJURY_PREVENTION
-    emergency_settings: http://13.81.34.152:1101/resource/authority/health-theme/EMERGENCY_SETTINGS
-    cancer_disease: http://13.81.34.152:1101/resource/authority/health-theme/CANCER_DISEASE
-    vector_diseases: http://13.81.34.152:1101/resource/authority/health-theme/VECTOR_DISEASES
-    health_products: http://13.81.34.152:1101/resource/authority/health-theme/HEALTH_PRODUCTS
-    noncommunicable_diseases: http://13.81.34.152:1101/resource/authority/health-theme/NONCOMMUNICABLE_DISEASES
-    mental_health: http://13.81.34.152:1101/resource/authority/health-theme/MENTAL_HEALTH
-    reproductive_health: http://13.81.34.152:1101/resource/authority/health-theme/REPRODUCTIVE_HEALTH
-    nutrition_security: http://13.81.34.152:1101/resource/authority/health-theme/NUTRITION_SECURITY
-    tropical_diseases: http://13.81.34.152:1101/resource/authority/health-theme/TROPICAL_DISEASES
+    climate_health: http://healthdataportal.eu/resource/authority/health-theme/CLIMATE_HEALTH
+    antimicrobial_control: http://healthdataportal.eu/resource/authority/health-theme/ANTIMICROBIAL_CONTROL
+    environmental_health: http://healthdataportal.eu/resource/authority/health-theme/ENVIRONMENTAL_HEALTH
+    blood_infections: http://healthdataportal.eu/resource/authority/health-theme/BLOOD_INFECTIONS
+    health_systems: http://healthdataportal.eu/resource/authority/health-theme/HEALTH_SYSTEMS
+    sensory_health: http://healthdataportal.eu/resource/authority/health-theme/SENSORY_HEALTH
+    respiratory_diseases: http://healthdataportal.eu/resource/authority/health-theme/RESPIRATORY_DISEASES
+    lifecourse_health: http://healthdataportal.eu/resource/authority/health-theme/LIFECOURSE_HEALTH
+    immunization_diseases: http://healthdataportal.eu/resource/authority/health-theme/IMMUNIZATION_DISEASES
+    enteric_infections: http://healthdataportal.eu/resource/authority/health-theme/ENTERIC_INFECTIONS
+    injury_prevention: http://healthdataportal.eu/resource/authority/health-theme/INJURY_PREVENTION
+    emergency_settings: http://healthdataportal.eu/resource/authority/health-theme/EMERGENCY_SETTINGS
+    cancer_disease: http://healthdataportal.eu/resource/authority/health-theme/CANCER_DISEASE
+    vector_diseases: http://healthdataportal.eu/resource/authority/health-theme/VECTOR_DISEASES
+    health_products: http://healthdataportal.eu/resource/authority/health-theme/HEALTH_PRODUCTS
+    noncommunicable_diseases: http://healthdataportal.eu/resource/authority/health-theme/NONCOMMUNICABLE_DISEASES
+    mental_health: http://healthdataportal.eu/resource/authority/health-theme/MENTAL_HEALTH
+    reproductive_health: http://healthdataportal.eu/resource/authority/health-theme/REPRODUCTIVE_HEALTH
+    nutrition_security: http://healthdataportal.eu/resource/authority/health-theme/NUTRITION_SECURITY
+    tropical_diseases: http://healthdataportal.eu/resource/authority/health-theme/TROPICAL_DISEASES
   en:
     climate_health: Climate Health
     antimicrobial_control: Antimicrobial Control

--- a/src/dh_healthdcat/mapping/vocab/README.md
+++ b/src/dh_healthdcat/mapping/vocab/README.md
@@ -15,15 +15,18 @@ Fichiers vendus : `AccessRights`, `ApplicableRegulations`, `Booleans`,
 `PersonalData`, `PublicationsEuropAuthorityCountry`,
 `PublicationsEuropAuthorityLanguage`, `PublisherType`.
 
-⚠️ `HealthCategories.yml` et `HealthTheme.yml` pointent sur un hôte de
-développement en dur côté HDH (`http://13.81.34.152:1101/...`) — vu tel quel
-dans les fichiers sources du HDH, donc pas une erreur de recopie de notre
-part. Ce n'est pas bloquant côté `dh-healthdcat` : la shape SHACL n'exige
-qu'une IRI pour `healthdcatap:healthCategory`/`healthTheme`
-(`sh:nodeKind sh:BlankNodeOrIRI`, aucun `sh:in` restreignant les valeurs
-autorisées), donc l'hôte exact ne fait pas échouer la validation. Si le HDH
-republie un jour ces dictionnaires sur un hôte de production, un simple
-resynchronisation de ces deux fichiers suffit — voir la politique ci-dessus.
+⚠️ `HealthCategories.yml` et `HealthTheme.yml` résolvent vers
+`http://healthdataportal.eu/resource/authority/{healthcategories,health-theme}/…`,
+le namespace SEMIC HealthDCAT-AP (le même que `PublisherType.yml`). Aucun hôte
+de vocabulaire **canonique** n'est publié à ce jour pour ces deux termes (le
+vocabulaire HealthDCAT-AP `healthCategory` n'est pas encore créé côté EC ; le
+Publications Office est pressenti à terme) — ces IRI ne sont donc pas encore
+déréférençables. Ce n'est pas bloquant : la shape SHACL n'exige qu'une IRI
+pour `healthdcatap:healthCategory`/`healthTheme` (`sh:nodeKind sh:BlankNodeOrIRI`,
+aucun `sh:in`), donc l'hôte exact ne fait pas échouer la validation. Les
+sources HDH portaient historiquement un hôte de dév en dur
+(`http://13.81.34.152:1101/…`), repointé ici (issue #6) ; resynchroniser ces
+deux fichiers quand un hôte officiel paraîtra.
 
 Trois fichiers sont d'auteur (pas vendus du HDH, qui ne publie pas de
 dictionnaire équivalent) :

--- a/tests/unit/test_vocabularies.py
+++ b/tests/unit/test_vocabularies.py
@@ -51,6 +51,10 @@ def test_reference_specification_maps_standards_to_canonical_uris():
         v.REFERENCE_SPECIFICATION.resolve("OSIRIS")
 
 
-def test_health_category_and_theme_use_hdh_dev_host():
-    # Question ouverte Q1 de la spec : ne pas "corriger" cette URI par erreur.
-    assert v.HEALTH_CATEGORY.resolve("HRAD").startswith("http://13.81.34.152:1101/")
+def test_health_category_and_theme_use_semic_authority_host():
+    # Aucun hôte de vocab canonique n'existe encore pour healthCategory /
+    # healthTheme (vocab HealthDCAT-AP non publié). On aligne sur le namespace
+    # SEMIC healthdataportal.eu, comme PublisherType.yml — non déréférençable
+    # pour l'instant, mais un identifiant SEMIC plutôt qu'une IP de dev.
+    assert v.HEALTH_CATEGORY.resolve("HRAD") == "http://healthdataportal.eu/resource/authority/healthcategories/HRAD"
+    assert v.HEALTH_THEME.resolve("health_systems") == "http://healthdataportal.eu/resource/authority/health-theme/HEALTH_SYSTEMS"


### PR DESCRIPTION
Closes #6 — carte wayfinder #1, `consolidation-todo` §C.6 (« dette connue »).

**PR empilée** sur #11 (`feat/reference-specification-vocab`). Cible cette branche ; à rebaser sur `main` après merge de #11.

## Contexte (investigation AFK)

Aucun hôte de vocabulaire **canonique** n'existe pour `healthCategory` / `healthTheme` :
- historique git : 1 seul commit, aucun hôte antérieur ;
- dépôts exporteur + registre : `13.81.34.152:1101` partout signalé « dette exporteur à corriger », jamais de remplaçant nommé ;
- spec HealthDCAT-AP R7 : vocab `healthCategory` *« currently not yet created »* ; Publications Office pressenti à terme, rien de concret ;
- `healthdataportal.eu` (namespace SEMIC, déjà utilisé par `PublisherType.yml`) : domaine nu sans cert TLS valide → pas résolvable non plus, mais c'est un **identifiant SEMIC** ;
- pas de clone local du dépôt HDH pour vérifier une éventuelle MAJ amont.

## Quoi

`HealthCategories.yml` / `HealthTheme.yml` : `http://13.81.34.152:1101/...` → `http://healthdataportal.eu/resource/authority/{healthcategories,health-theme}/...` (chemins inchangés). Aligne sur `PublisherType.yml`. Test `test_vocabularies.py` mis à jour (assertions d'égalité exactes) ; `vocab/README.md` + `docs/mapping.md` mis à jour.

Le validateur HDH n'exige qu'une IRI (`sh:BlankNodeOrIRI`, aucun `sh:in`) → conformité inchangée. `uv run pytest` : 102 au vert.

## Écart résiduel (→ ADR #8, §E)

Ces IRI ne sont pas déréférençables (même statut que `PublisherType.yml`). Resynchroniser les deux fichiers quand l'EC/HDH publiera le vocabulaire officiel.