### PR TITLE
chore: Repointer HealthCategories/HealthTheme sur le namespace SEMIC (récup #12)

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -143,5 +143,5 @@ détail exact.
 | `prov:qualifiedAttribution` (dataController/dataProcessor) | Propriétés existantes non reprises, pas d'équivalent HealthDCAT-AP direct | P2 |
 | `dqv:hasQualityAnnotation` | Entités `ASSERTION` (quality-layer) non lues | P2 |
 | `fr.aphp.healthdcat.publishingFrequency` allowedValue `IRREGULAR` | Le vocabulaire HDH `Frequency` attend `IRREG` — écart détecté par `resolve_or_warn` (dégradé en avertissement, pas d'échec) | à corriger dans `assets.yml` |
-| `HealthCategories`/`HealthTheme` (URIs HDH) | Pointent sur un hôte de développement en dur (`http://13.81.34.152:1101/...`) côté HDH | à reconfirmer avant publication en production |
+| `HealthCategories`/`HealthTheme` (URIs) | Repointées de l'hôte de dév en dur (`13.81.34.152:1101`) vers le namespace SEMIC `http://healthdataportal.eu/resource/authority/...` (issue #6). Aucun hôte canonique publié à ce jour → IRI pas encore déréférençables | resynchroniser quand l'EC/HDH publiera le vocabulaire officiel |
 | `fr.aphp.healthdcat.retentionPeriod` (ancienne, texte ISO 8601) | Dépréciée au profit de `retentionPeriodStart`/`retentionPeriodEnd`, toujours déclarée dans `assets.yml` mais plus exportée | à retirer une fois la curation terminée |

--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -59,6 +59,7 @@ vérifié par le SHACL de base · `⚙️` = dérivé/calculé, pas une saisie.
 | `dpv:hasLegalBasis` | | `legalBasis` → `LegalBasis` (vocabulaire d'auteur) | |
 | `dpv:hasPersonalData` | | `fr.aphp.healthdcat.personalData` → `PersonalData` | |
 | `healthdcatap:hasStructuredData` (`xsd:boolean`, R7 1..1) | | dérivé : `true` ssi ≥1 asset porte un `schemaMetadata` (→ `csvw:Table`) | `model.py::HealthDataset.has_structured_data` ; toujours émis, `false` compris ; validateur HDH indifférent |
+| `healthdcatap:hasVariables` → `csvw:TableGroup` (R7, `minCount 1` si `hasStructuredData`) | | ⚙️ regroupe par `csvw:table` toutes les `csvw:Table` du dataset (distributions + samples) | `dataset.py` ; émis ssi ≥1 `csvw:Table` ; nœud `<tablegroup:{uuid}>` ; validateur HDH indifférent (pas de `:CSVWTableGroup_Shape`) |
 | `foaf:page` | | `institutionalMemory.elements[].url` | non lu en v1 |
 | `dqv:hasQualityAnnotation` | | entités `ASSERTION` | **P2, non implémenté** |
 

--- a/src/dh_healthdcat/mapping/dataset.py
+++ b/src/dh_healthdcat/mapping/dataset.py
@@ -24,6 +24,7 @@ from rdflib.namespace import RDFS
 from dh_healthdcat.mapping import agent as agent_mapping
 from dh_healthdcat.mapping import distribution as distribution_mapping
 from dh_healthdcat.mapping.namespaces import (
+    CSVW,
     DCAT,
     DCATAP,
     DCT,
@@ -213,14 +214,31 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     graph.add((uri, HEALTHDCATAP.hasStructuredData, Literal(dataset.has_structured_data, datatype=XSD.boolean)))
 
     # --- Distributions / échantillons ---
+    table_nodes: list[URIRef] = []
     for distribution in dataset.distributions:
-        distribution_mapping.add_distribution(graph, uri, distribution, dataset.title, dataset.issues)
+        _, table_node = distribution_mapping.add_distribution(graph, uri, distribution, dataset.title, dataset.issues)
+        if table_node is not None:
+            table_nodes.append(table_node)
     if not dataset.distributions:
         _missing(dataset, "dcat:distribution", "dataProductProperties.assets (aucun asset non marqué dcat:sample)")
 
     for sample in dataset.samples:
-        distribution_mapping.add_distribution(graph, uri, sample, dataset.title, dataset.issues)
+        _, table_node = distribution_mapping.add_distribution(graph, uri, sample, dataset.title, dataset.issues)
+        if table_node is not None:
+            table_nodes.append(table_node)
     if not dataset.samples:
         _missing(dataset, "adms:sample", "dataProductProperties.assets marqué du tag dcat:sample (aucun trouvé)")
+
+    # --- healthdcatap:hasVariables → csvw:TableGroup (R7) : regroupe par
+    # csvw:table toutes les csvw:Table du dataset. Émis ssi ≥ 1 table (⇔
+    # has_structured_data ; R7 : hasVariables interdit si hasStructuredData
+    # est faux). Le validateur HDH n'a pas de shape TableGroup et
+    # :Dataset_Shape n'est pas sh:closed — émission sans effet sur lui. ---
+    if table_nodes:
+        table_group = node_uri("tablegroup", str(uri))
+        graph.add((uri, HEALTHDCATAP.hasVariables, table_group))
+        graph.add((table_group, RDF.type, CSVW.TableGroup))
+        for table_node in table_nodes:
+            graph.add((table_group, CSVW.table, table_node))
 
     return graph

--- a/src/dh_healthdcat/mapping/distribution.py
+++ b/src/dh_healthdcat/mapping/distribution.py
@@ -42,8 +42,12 @@ def add_distribution(
     distribution: Distribution,
     dataset_name: str,
     issues: list[ValidationIssue],
-) -> URIRef:
-    """Ajoute un dcat:distribution ou adms:sample selon `distribution.is_sample`."""
+) -> tuple[URIRef, URIRef | None]:
+    """Ajoute un dcat:distribution ou adms:sample selon `distribution.is_sample`.
+
+    Renvoie `(nœud distribution, nœud csvw:Table | None)` — l'appelant
+    (`mapping/dataset.py`) collecte les nœuds table pour les regrouper sous le
+    `csvw:TableGroup` porté par `healthdcatap:hasVariables`."""
 
     kind = "sample" if distribution.is_sample else "distribution"
     node = node_uri(kind, distribution.source_urn or distribution.node_id)
@@ -110,10 +114,11 @@ def add_distribution(
         if not distribution.rights:
             _missing(issues, dataset_name, dataset_urn_or_source(distribution), "dct:rights", "fr.aphp.healthdcat.license (DataProduct, hérité)")
 
+    table_node = None
     if distribution.table is not None:
-        _add_table(graph, node, distribution, distribution.table)
+        table_node = _add_table(graph, node, distribution, distribution.table)
 
-    return node
+    return node, table_node
 
 
 def dataset_urn_or_source(distribution: Distribution) -> str:
@@ -123,11 +128,13 @@ def dataset_urn_or_source(distribution: Distribution) -> str:
     return distribution.source_urn
 
 
-def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distribution, table: Table) -> None:
+def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distribution, table: Table) -> URIRef:
     """csvw:Table. Aucun prédicat Distribution→Table n'est défini par les shapes HDH
     (:CSVWTableShape cible juste `csvw:Table` en isolation) ; on relie table et
     distribution par le même `csvw:url` que `dcat:accessURL` plutôt que
-    d'inventer un prédicat."""
+    d'inventer un prédicat. Le rattachement R7 se fait en amont, au niveau
+    `dcat:Dataset` : `mapping/dataset.py` regroupe le nœud renvoyé ici sous un
+    `csvw:TableGroup` porté par `healthdcatap:hasVariables`."""
 
     table_node = node_uri("table", str(distribution_node))
     graph.add((table_node, RDF.type, CSVW.Table))
@@ -148,3 +155,5 @@ def _add_table(graph: Graph, distribution_node: URIRef, distribution: Distributi
         graph.add((column_node, CSVW.datatype, Literal(column.datatype)))
         if column.description:
             graph.add((column_node, DCT.description, Literal(column.description, lang="fr")))
+
+    return table_node

--- a/src/dh_healthdcat/mapping/vocab/HealthCategories.yml
+++ b/src/dh_healthdcat/mapping/vocab/HealthCategories.yml
@@ -1,23 +1,23 @@
 HealthCategories:
   col: A
   vocabulary_list:
-    EHRS: http://13.81.34.152:1101/resource/authority/healthcategories/EHRS
-    DIOH: http://13.81.34.152:1101/resource/authority/healthcategories/DIOH
-    NRPE: http://13.81.34.152:1101/resource/authority/healthcategories/NRPE
-    RPDG: http://13.81.34.152:1101/resource/authority/healthcategories/RPDG
-    HRAD: http://13.81.34.152:1101/resource/authority/healthcategories/HRAD
-    HGPD: http://13.81.34.152:1101/resource/authority/healthcategories/HGPD
-    HPML: http://13.81.34.152:1101/resource/authority/healthcategories/HPML
-    PGEH: http://13.81.34.152:1101/resource/authority/healthcategories/PGEH
-    WELA: http://13.81.34.152:1101/resource/authority/healthcategories/WELA
-    IDHP: http://13.81.34.152:1101/resource/authority/healthcategories/IDHP
-    PHDR: http://13.81.34.152:1101/resource/authority/healthcategories/PHDR
-    MRMR: http://13.81.34.152:1101/resource/authority/healthcategories/MRMR
-    EHCT: http://13.81.34.152:1101/resource/authority/healthcategories/EHCT
-    EMRD: http://13.81.34.152:1101/resource/authority/healthcategories/EMRD
-    RMMD: http://13.81.34.152:1101/resource/authority/healthcategories/RMMD
-    RQSH: http://13.81.34.152:1101/resource/authority/healthcategories/RQSH
-    EINS: http://13.81.34.152:1101/resource/authority/healthcategories/EINS
+    EHRS: http://healthdataportal.eu/resource/authority/healthcategories/EHRS
+    DIOH: http://healthdataportal.eu/resource/authority/healthcategories/DIOH
+    NRPE: http://healthdataportal.eu/resource/authority/healthcategories/NRPE
+    RPDG: http://healthdataportal.eu/resource/authority/healthcategories/RPDG
+    HRAD: http://healthdataportal.eu/resource/authority/healthcategories/HRAD
+    HGPD: http://healthdataportal.eu/resource/authority/healthcategories/HGPD
+    HPML: http://healthdataportal.eu/resource/authority/healthcategories/HPML
+    PGEH: http://healthdataportal.eu/resource/authority/healthcategories/PGEH
+    WELA: http://healthdataportal.eu/resource/authority/healthcategories/WELA
+    IDHP: http://healthdataportal.eu/resource/authority/healthcategories/IDHP
+    PHDR: http://healthdataportal.eu/resource/authority/healthcategories/PHDR
+    MRMR: http://healthdataportal.eu/resource/authority/healthcategories/MRMR
+    EHCT: http://healthdataportal.eu/resource/authority/healthcategories/EHCT
+    EMRD: http://healthdataportal.eu/resource/authority/healthcategories/EMRD
+    RMMD: http://healthdataportal.eu/resource/authority/healthcategories/RMMD
+    RQSH: http://healthdataportal.eu/resource/authority/healthcategories/RQSH
+    EINS: http://healthdataportal.eu/resource/authority/healthcategories/EINS
   en:
     EHRS: Electronic Health Data from EHRs
     DIOH: Data on factors impacting on health, including socio-economic, environmental

--- a/src/dh_healthdcat/mapping/vocab/HealthTheme.yml
+++ b/src/dh_healthdcat/mapping/vocab/HealthTheme.yml
@@ -1,26 +1,26 @@
 HealthTheme:
   col: A
   vocabulary_list:
-    climate_health: http://13.81.34.152:1101/resource/authority/health-theme/CLIMATE_HEALTH
-    antimicrobial_control: http://13.81.34.152:1101/resource/authority/health-theme/ANTIMICROBIAL_CONTROL
-    environmental_health: http://13.81.34.152:1101/resource/authority/health-theme/ENVIRONMENTAL_HEALTH
-    blood_infections: http://13.81.34.152:1101/resource/authority/health-theme/BLOOD_INFECTIONS
-    health_systems: http://13.81.34.152:1101/resource/authority/health-theme/HEALTH_SYSTEMS
-    sensory_health: http://13.81.34.152:1101/resource/authority/health-theme/SENSORY_HEALTH
-    respiratory_diseases: http://13.81.34.152:1101/resource/authority/health-theme/RESPIRATORY_DISEASES
-    lifecourse_health: http://13.81.34.152:1101/resource/authority/health-theme/LIFECOURSE_HEALTH
-    immunization_diseases: http://13.81.34.152:1101/resource/authority/health-theme/IMMUNIZATION_DISEASES
-    enteric_infections: http://13.81.34.152:1101/resource/authority/health-theme/ENTERIC_INFECTIONS
-    injury_prevention: http://13.81.34.152:1101/resource/authority/health-theme/INJURY_PREVENTION
-    emergency_settings: http://13.81.34.152:1101/resource/authority/health-theme/EMERGENCY_SETTINGS
-    cancer_disease: http://13.81.34.152:1101/resource/authority/health-theme/CANCER_DISEASE
-    vector_diseases: http://13.81.34.152:1101/resource/authority/health-theme/VECTOR_DISEASES
-    health_products: http://13.81.34.152:1101/resource/authority/health-theme/HEALTH_PRODUCTS
-    noncommunicable_diseases: http://13.81.34.152:1101/resource/authority/health-theme/NONCOMMUNICABLE_DISEASES
-    mental_health: http://13.81.34.152:1101/resource/authority/health-theme/MENTAL_HEALTH
-    reproductive_health: http://13.81.34.152:1101/resource/authority/health-theme/REPRODUCTIVE_HEALTH
-    nutrition_security: http://13.81.34.152:1101/resource/authority/health-theme/NUTRITION_SECURITY
-    tropical_diseases: http://13.81.34.152:1101/resource/authority/health-theme/TROPICAL_DISEASES
+    climate_health: http://healthdataportal.eu/resource/authority/health-theme/CLIMATE_HEALTH
+    antimicrobial_control: http://healthdataportal.eu/resource/authority/health-theme/ANTIMICROBIAL_CONTROL
+    environmental_health: http://healthdataportal.eu/resource/authority/health-theme/ENVIRONMENTAL_HEALTH
+    blood_infections: http://healthdataportal.eu/resource/authority/health-theme/BLOOD_INFECTIONS
+    health_systems: http://healthdataportal.eu/resource/authority/health-theme/HEALTH_SYSTEMS
+    sensory_health: http://healthdataportal.eu/resource/authority/health-theme/SENSORY_HEALTH
+    respiratory_diseases: http://healthdataportal.eu/resource/authority/health-theme/RESPIRATORY_DISEASES
+    lifecourse_health: http://healthdataportal.eu/resource/authority/health-theme/LIFECOURSE_HEALTH
+    immunization_diseases: http://healthdataportal.eu/resource/authority/health-theme/IMMUNIZATION_DISEASES
+    enteric_infections: http://healthdataportal.eu/resource/authority/health-theme/ENTERIC_INFECTIONS
+    injury_prevention: http://healthdataportal.eu/resource/authority/health-theme/INJURY_PREVENTION
+    emergency_settings: http://healthdataportal.eu/resource/authority/health-theme/EMERGENCY_SETTINGS
+    cancer_disease: http://healthdataportal.eu/resource/authority/health-theme/CANCER_DISEASE
+    vector_diseases: http://healthdataportal.eu/resource/authority/health-theme/VECTOR_DISEASES
+    health_products: http://healthdataportal.eu/resource/authority/health-theme/HEALTH_PRODUCTS
+    noncommunicable_diseases: http://healthdataportal.eu/resource/authority/health-theme/NONCOMMUNICABLE_DISEASES
+    mental_health: http://healthdataportal.eu/resource/authority/health-theme/MENTAL_HEALTH
+    reproductive_health: http://healthdataportal.eu/resource/authority/health-theme/REPRODUCTIVE_HEALTH
+    nutrition_security: http://healthdataportal.eu/resource/authority/health-theme/NUTRITION_SECURITY
+    tropical_diseases: http://healthdataportal.eu/resource/authority/health-theme/TROPICAL_DISEASES
   en:
     climate_health: Climate Health
     antimicrobial_control: Antimicrobial Control

--- a/src/dh_healthdcat/mapping/vocab/README.md
+++ b/src/dh_healthdcat/mapping/vocab/README.md
@@ -15,15 +15,18 @@ Fichiers vendus : `AccessRights`, `ApplicableRegulations`, `Booleans`,
 `PersonalData`, `PublicationsEuropAuthorityCountry`,
 `PublicationsEuropAuthorityLanguage`, `PublisherType`.
 
-⚠️ `HealthCategories.yml` et `HealthTheme.yml` pointent sur un hôte de
-développement en dur côté HDH (`http://13.81.34.152:1101/...`) — vu tel quel
-dans les fichiers sources du HDH, donc pas une erreur de recopie de notre
-part. Ce n'est pas bloquant côté `dh-healthdcat` : la shape SHACL n'exige
-qu'une IRI pour `healthdcatap:healthCategory`/`healthTheme`
-(`sh:nodeKind sh:BlankNodeOrIRI`, aucun `sh:in` restreignant les valeurs
-autorisées), donc l'hôte exact ne fait pas échouer la validation. Si le HDH
-republie un jour ces dictionnaires sur un hôte de production, un simple
-resynchronisation de ces deux fichiers suffit — voir la politique ci-dessus.
+⚠️ `HealthCategories.yml` et `HealthTheme.yml` résolvent vers
+`http://healthdataportal.eu/resource/authority/{healthcategories,health-theme}/…`,
+le namespace SEMIC HealthDCAT-AP (le même que `PublisherType.yml`). Aucun hôte
+de vocabulaire **canonique** n'est publié à ce jour pour ces deux termes (le
+vocabulaire HealthDCAT-AP `healthCategory` n'est pas encore créé côté EC ; le
+Publications Office est pressenti à terme) — ces IRI ne sont donc pas encore
+déréférençables. Ce n'est pas bloquant : la shape SHACL n'exige qu'une IRI
+pour `healthdcatap:healthCategory`/`healthTheme` (`sh:nodeKind sh:BlankNodeOrIRI`,
+aucun `sh:in`), donc l'hôte exact ne fait pas échouer la validation. Les
+sources HDH portaient historiquement un hôte de dév en dur
+(`http://13.81.34.152:1101/…`), repointé ici (issue #6) ; resynchroniser ces
+deux fichiers quand un hôte officiel paraîtra.
 
 Trois fichiers sont d'auteur (pas vendus du HDH, qui ne publie pas de
 dictionnaire équivalent) :

--- a/tests/unit/test_mapping_dataset.py
+++ b/tests/unit/test_mapping_dataset.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from rdflib import XSD, Literal
+from rdflib import RDF, XSD, Literal
 
 from dh_healthdcat.mapping import vocabularies as v
 from dh_healthdcat.mapping.dataset import dataset_to_graph
-from dh_healthdcat.mapping.namespaces import HEALTHDCATAP
+from dh_healthdcat.mapping.namespaces import CSVW, HEALTHDCATAP
 from dh_healthdcat.model import (
     Agent,
     Column,
@@ -158,6 +158,47 @@ def test_has_structured_data_false_is_emitted_when_no_asset_carries_a_schema():
     values = list(graph.objects(dataset_uri, HEALTHDCATAP.hasStructuredData))
 
     assert values == [Literal(False, datatype=XSD.boolean)]
+
+
+def test_has_variables_groups_every_csvw_table_under_one_tablegroup():
+    """healthdcatap:hasVariables → csvw:TableGroup au niveau du dcat:Dataset,
+    regroupant par csvw:table toutes les csvw:Table déjà produites depuis
+    schemaMetadata (distributions comme échantillons)."""
+
+    dataset = _fully_conformant_dataset()  # 1 csvw:Table, portée par le sample
+    graph = dataset_to_graph(dataset)
+
+    dataset_uri = next(graph.subjects(HEALTHDCATAP.hasVariables, None))
+    groups = list(graph.objects(dataset_uri, HEALTHDCATAP.hasVariables))
+    assert len(groups) == 1
+    table_group = groups[0]
+    assert (table_group, RDF.type, CSVW.TableGroup) in graph
+
+    grouped = set(graph.objects(table_group, CSVW.table))
+    all_tables = set(graph.subjects(RDF.type, CSVW.Table))
+    assert grouped == all_tables
+    assert len(grouped) == 1
+
+
+def test_no_tablegroup_when_no_asset_carries_a_schema():
+    """R7 interdit healthdcatap:hasVariables quand hasStructuredData est faux :
+    aucune table → aucun csvw:TableGroup, aucun hasVariables."""
+
+    dataset = _fully_conformant_dataset()
+    dataset.samples = (
+        Distribution(
+            node_id=dataset.samples[0].node_id,
+            title=dataset.samples[0].title,
+            is_sample=True,
+            access_url=dataset.samples[0].access_url,
+            source_urn=dataset.samples[0].source_urn,
+        ),
+    )
+
+    graph = dataset_to_graph(dataset)
+
+    assert list(graph.objects(None, HEALTHDCATAP.hasVariables)) == []
+    assert list(graph.subjects(RDF.type, CSVW.TableGroup)) == []
 
 
 def test_distribution_requires_stricter_fields_than_sample():

--- a/tests/unit/test_vocabularies.py
+++ b/tests/unit/test_vocabularies.py
@@ -51,6 +51,10 @@ def test_reference_specification_maps_standards_to_canonical_uris():
         v.REFERENCE_SPECIFICATION.resolve("OSIRIS")
 
 
-def test_health_category_and_theme_use_hdh_dev_host():
-    # Question ouverte Q1 de la spec : ne pas "corriger" cette URI par erreur.
-    assert v.HEALTH_CATEGORY.resolve("HRAD").startswith("http://13.81.34.152:1101/")
+def test_health_category_and_theme_use_semic_authority_host():
+    # Aucun hôte de vocab canonique n'existe encore pour healthCategory /
+    # healthTheme (vocab HealthDCAT-AP non publié). On aligne sur le namespace
+    # SEMIC healthdataportal.eu, comme PublisherType.yml — non déréférençable
+    # pour l'instant, mais un identifiant SEMIC plutôt qu'une IP de dev.
+    assert v.HEALTH_CATEGORY.resolve("HRAD") == "http://healthdataportal.eu/resource/authority/healthcategories/HRAD"
+    assert v.HEALTH_THEME.resolve("health_systems") == "http://healthdataportal.eu/resource/authority/health-theme/HEALTH_SYSTEMS"


### PR DESCRIPTION
Ré-application sur `main` de la PR #12 (ticket #6), dont le merge a atterri sur la branche de base obsolète `feat/reference-specification-vocab` sans jamais toucher `main`.

**Empilée sur #13** (`recover/hasvariables`) : contient aussi le commit `1318608` de #13 tant que celle-ci n'est pas mergée. Merger **#13 d'abord**, puis cette PR se réduira à `ef42022`.

Cherry-pick de `ef42022` — contenu identique, revu et CI-vert en #12. Voir #12 / issue #6 pour le détail.

## Résumé

`HealthCategories.yml` / `HealthTheme.yml` : `http://13.81.34.152:1101/...` → `http://healthdataportal.eu/resource/authority/{healthcategories,health-theme}/...` (namespace SEMIC, comme `PublisherType.yml`). Aucun hôte canonique n'existe encore ; IRI non déréférençables mais identifiant SEMIC. Validateur HDH indifférent. `uv run pytest` : 104 au vert.