### PR TITLE
feat: Petites corrections de l'émetteur (issued / DOI / distributionStatus)

### DIFF
--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -45,13 +45,13 @@ vérifié par le SHACL de base · `⚙️` = dérivé/calculé, pas une saisie.
 | `dcat:distribution` | M, ≥1 | assets non tagués `dcat:sample` | dataset.py (reader) |
 | `adms:sample` | M, ≥1 | assets tagués `dcat:sample` | dataset.py (reader) |
 | `dct:language` | | `fr.aphp.healthdcat.language` → `PublicationsEuropAuthorityLanguage` | |
-| `dct:issued` | | `fr.aphp.healthdcat.issued` | |
+| `dct:issued` (`xsd:date`) | | `fr.aphp.healthdcat.issued` (un `date` — émis en `xsd:date`, pas `xsd:dateTime`) | |
 | `dct:modified` | | `dataProductProperties.lastModified` | |
 | `dct:temporal` | | `temporalCoverageStart`/`End` | |
 | `dct:accrualPeriodicity` | | `publishingFrequency` → `Frequency` | |
 | `dct:conformsTo` | | `referenceSpecification` → `ReferenceSpecification` (vocab d'auteur) ; code hors vocab → `urn:aphp:conformsTo:<code>` (ex. `OSIRIS`) | |
 | `dct:license` | | `license`, passage direct | |
-| `dct:isReferencedBy` | | `fr.aphp.healthdcat.isReferencedBy` | |
+| `dct:isReferencedBy` | | `fr.aphp.healthdcat.isReferencedBy` ; DOI nu (`10.x/…`) ou `doi:` préfixé → `https://doi.org/…` | |
 | `healthdcatap:numberOfRecords`/`numberOfUniqueIndividuals`/`min|maxTypicalAge` | | `number` | |
 | `healthdcatap:populationCoverage` | | `fr.aphp.healthdcat.populationCoverage` | |
 | `healthdcatap:retentionPeriod` | | `retentionPeriodStart`/`End` → `dct:PeriodOfTime` | |
@@ -95,13 +95,14 @@ valide avec la seule `dcat:accessURL`.
 | `dct:rights` (nœud `dct:RightsStatement`, pas un littéral direct — exigé `sh:BlankNodeOrIRI`) | M, =1 | — | hérité de `fr.aphp.healthdcat.license` du DataProduct |
 | `dcatap:applicableLegislation` | M | — | hérité du DataProduct si l'asset n'en a pas |
 | `dct:title` / `dct:description` | | | `datasetProperties.name`/`.description`, fusion `editableDatasetProperties` |
+| `adms:status` | | | `fr.aphp.healthdcat.distributionStatus` → `DistributionStatus` ; `deprecation.deprecated` écrase en `WITHDRAWN` |
 | `csvw:Table` → `csvw:column` | | | `schemaMetadata.fields` |
 
 ## Vocabulaires (`mapping/vocab/`)
 
 12 fichiers vendus tels quels depuis
 `hdh/.../controlled_vocabulary/controled_voc_dicts/` (voir `vocab/README.md`
-pour la liste et la procédure de resynchronisation), plus trois fichiers
+pour la liste et la procédure de resynchronisation), plus quatre fichiers
 d'auteur :
 
 - **`LegalBasis.yml`** — mapping des 12 codes `eu-gdpr:A6-1-*`/`eu-gdpr:A9-2-*`
@@ -114,6 +115,9 @@ d'auteur :
   `OMOP-CDM-5.4` → page GitHub Pages OHDSI versionnée, `HL7v2` → `urn:hl7-org:v2xml`
   (URIs vérifiées le 2026-08-28, cf. `docs/research/reference-specification-uris.md`).
   Câblé dans `reader/dataproduct.py` ; code hors vocab → `urn:aphp:conformsTo:<code>`.
+- **`DistributionStatus.yml`** — `COMPLETED` / `WITHDRAWN` → NAL EU Publications
+  Office `.../distribution-status/*`. Câblé dans `reader/dataset.py` (`adms:status`) ;
+  une dépréciation DataHub écrase en `WITHDRAWN`.
 
 Toute résolution échoue explicitement (`UnknownVocabularyValueError`) plutôt
 que de retomber sur un `skos:prefLabel "NA"@en` silencieux comme le fait le

--- a/src/dh_healthdcat/mapping/dataset.py
+++ b/src/dh_healthdcat/mapping/dataset.py
@@ -165,7 +165,7 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
 
     # --- Champs recommandés / optionnels, sans exigence de cardinalité minimale ---
     if dataset.issued:
-        graph.add((uri, DCT.issued, Literal(dataset.issued, datatype=XSD.dateTime)))
+        graph.add((uri, DCT.issued, Literal(dataset.issued, datatype=XSD.date)))
     if dataset.modified:
         graph.add((uri, DCT.modified, Literal(dataset.modified, datatype=XSD.dateTime)))
     if dataset.accrual_periodicity:

--- a/src/dh_healthdcat/mapping/vocab/DistributionStatus.yml
+++ b/src/dh_healthdcat/mapping/vocab/DistributionStatus.yml
@@ -1,0 +1,13 @@
+# Vocabulaire d'auteur (dh-healthdcat), pas vendu du HDH — le HDH ne publie pas
+# de dictionnaire "statut de distribution".
+#
+# Couvre les valeurs de `fr.aphp.healthdcat.distributionStatus` (→ adms:status),
+# sous-ensemble du NAL EU Publications Office `distribution-status` retenu par le
+# registre (`allowedValues: COMPLETED, WITHDRAWN`).
+DistributionStatus:
+  vocabulary_list:
+    COMPLETED: "http://publications.europa.eu/resource/authority/distribution-status/COMPLETED"
+    WITHDRAWN: "http://publications.europa.eu/resource/authority/distribution-status/WITHDRAWN"
+  fr:
+    COMPLETED: "Finalisée"
+    WITHDRAWN: "Retirée"

--- a/src/dh_healthdcat/mapping/vocab/README.md
+++ b/src/dh_healthdcat/mapping/vocab/README.md
@@ -28,7 +28,7 @@ sources HDH portaient historiquement un hôte de dév en dur
 (`http://13.81.34.152:1101/…`), repointé ici (issue #6) ; resynchroniser ces
 deux fichiers quand un hôte officiel paraîtra.
 
-Trois fichiers sont d'auteur (pas vendus du HDH, qui ne publie pas de
+Quatre fichiers sont d'auteur (pas vendus du HDH, qui ne publie pas de
 dictionnaire équivalent) :
 
 - `LegalBasis.yml` : mapping des 12 codes `A6-1-*`/`A9-2-*` de
@@ -45,3 +45,8 @@ dictionnaire équivalent) :
   `docs/research/reference-specification-uris.md`). Tout autre code (p. ex.
   `OSIRIS`) retombe sur `urn:aphp:conformsTo:<code>` côté
   `reader/dataproduct.py`.
+- `DistributionStatus.yml` : `COMPLETED` / `WITHDRAWN` de
+  `fr.aphp.healthdcat.distributionStatus` (→ `adms:status`) vers le NAL EU
+  Publications Office `.../distribution-status/*` (sous-ensemble retenu par le
+  registre). Câblé dans `reader/dataset.py` ; une dépréciation DataHub écrase
+  en `WITHDRAWN`.

--- a/src/dh_healthdcat/mapping/vocabularies.py
+++ b/src/dh_healthdcat/mapping/vocabularies.py
@@ -96,6 +96,7 @@ COUNTRY = _load("PublicationsEuropAuthorityCountry")
 LEGAL_BASIS = _load("LegalBasis")
 CODING_SYSTEM = _load("CodingSystem")
 REFERENCE_SPECIFICATION = _load("ReferenceSpecification")
+DISTRIBUTION_STATUS = _load("DistributionStatus")
 
 # dcat:theme n'a pas de dictionnaire dédié côté HDH (PublicationsEuropAuthorityTheme
 # existe mais sert au thème générique EU) ; HealthDCAT-AP impose la valeur HEAL a

--- a/src/dh_healthdcat/model.py
+++ b/src/dh_healthdcat/model.py
@@ -180,8 +180,8 @@ class HealthDataset:
     coding_system: tuple[str, ...] = ()
 
     # Temporel / cycle de vie
-    issued: datetime | None = None
-    modified: datetime | None = None
+    issued: date | None = None  # dct:issued — `fr.aphp.healthdcat.issued` est un date, émis en xsd:date
+    modified: datetime | None = None  # dct:modified — vrai horodatage (dataProductProperties.lastModified)
     temporal: PeriodOfTime | None = None
     accrual_periodicity: str | None = None
 

--- a/src/dh_healthdcat/reader/dataproduct.py
+++ b/src/dh_healthdcat/reader/dataproduct.py
@@ -91,6 +91,19 @@ def _resolve_one(
     )
 
 
+def _doi_to_uri(value: str) -> str:
+    """`dct:isReferencedBy` attend une IRI. Un DOI nu (`10.1234/…`) ou préfixé
+    `doi:` est normalisé en `https://doi.org/…` ; le reste (URL déjà complète,
+    autre URN) passe tel quel."""
+
+    stripped = value.strip()
+    if stripped.lower().startswith("doi:"):
+        return f"https://doi.org/{stripped[4:].strip()}"
+    if stripped.startswith("10."):
+        return f"https://doi.org/{stripped}"
+    return stripped
+
+
 def _as_uri(value: str | None, urn_namespace: str) -> str | None:
     """Si `value` ressemble déjà à une URI, le renvoie tel quel ; sinon
     l'enveloppe dans un URN stable pour rester `sh:nodeKind sh:IRI`-compatible
@@ -208,7 +221,10 @@ def read_data_product(
             if fallback:
                 conforms_to.append(fallback)
     license_ = props.get_string(ctx, entity, "fr.aphp.healthdcat.license", title, dataproduct_urn, issues)
-    is_referenced_by = props.get_strings(ctx, entity, "fr.aphp.healthdcat.isReferencedBy", title, dataproduct_urn, issues)
+    is_referenced_by = tuple(
+        _doi_to_uri(ref)
+        for ref in props.get_strings(ctx, entity, "fr.aphp.healthdcat.isReferencedBy", title, dataproduct_urn, issues)
+    )
 
     number_of_records = props.get_int(entity, "fr.aphp.healthdcat.numberOfRecords", title, dataproduct_urn, issues)
     number_of_unique_individuals = props.get_int(entity, "fr.aphp.healthdcat.numberOfUniqueIndividuals", title, dataproduct_urn, issues)
@@ -218,8 +234,7 @@ def read_data_product(
     provenance = props.get_string(ctx, entity, "fr.aphp.healthdcat.provenance", title, dataproduct_urn, issues)
     purpose = props.get_string(ctx, entity, "fr.aphp.healthdcat.purpose", title, dataproduct_urn, issues)
 
-    issued_date = props.get_date(entity, "fr.aphp.healthdcat.issued", title, dataproduct_urn, issues)
-    issued = datetime.combine(issued_date, datetime.min.time()) if issued_date else None
+    issued = props.get_date(entity, "fr.aphp.healthdcat.issued", title, dataproduct_urn, issues)  # date, émis en xsd:date
     modified = datetime.fromtimestamp(dp.lastModified.time / 1000) if getattr(dp, "lastModified", None) else None
 
     temporal_start = props.get_date(entity, "fr.aphp.healthdcat.temporalCoverageStart", title, dataproduct_urn, issues)

--- a/src/dh_healthdcat/reader/dataset.py
+++ b/src/dh_healthdcat/reader/dataset.py
@@ -115,9 +115,18 @@ def read_distribution(
         issues=issues,
     )
 
-    status_uri = None
+    # adms:status — le SP explicite fixe le statut ; une dépréciation DataHub
+    # écrase en WITHDRAWN (un asset déprécié n'est pas COMPLETED).
+    status_uri = resolve_or_warn(
+        v.DISTRIBUTION_STATUS,
+        props.get_string(ctx, entity, "fr.aphp.healthdcat.distributionStatus", parent_dataset_name, dataset_urn, issues),
+        dataset_name=parent_dataset_name,
+        dataset_urn=dataset_urn,
+        datahub_field="fr.aphp.healthdcat.distributionStatus",
+        issues=issues,
+    )
     if deprecation is not None and deprecation.deprecated:
-        status_uri = "http://publications.europa.eu/resource/authority/distribution-status/WITHDRAWN"
+        status_uri = v.DISTRIBUTION_STATUS.resolve("WITHDRAWN")
 
     table = None
     if schema is not None and schema.fields:

--- a/tests/fixtures/fake_datahub.py
+++ b/tests/fixtures/fake_datahub.py
@@ -75,6 +75,8 @@ def _entities() -> dict[str, dict]:
                     _sp("fr.aphp.healthdcat.license", "https://eds.aphp.fr/licence"),
                     # referenceSpecification : un code du vocab + un code local (OSIRIS)
                     _sp("fr.aphp.healthdcat.referenceSpecification", "HL7-FHIR-R4", "OSIRIS"),
+                    # isReferencedBy : DOI nu, DOI préfixé "doi:", et URL complète
+                    _sp("fr.aphp.healthdcat.isReferencedBy", "10.1234/abcd.2019", "doi:10.5555/xyz", "https://hal.science/hal-04"),
                     _sp("fr.aphp.healthdcat.numberOfRecords", "1000000000"),  # string au lieu de number : coercition
                     _sp("fr.aphp.healthdcat.publishingFrequency", "DAILY"),
                     _sp(UNDECLARED_PROPERTY, "x"),
@@ -103,7 +105,10 @@ def _entities() -> dict[str, dict]:
             ),
             "deprecation": None,
             "globalTags": NS(tags=[]),
-            "structuredProperties": NS(properties=[_sp("fr.aphp.healthdcat.accessUrl", "https://s3.aphp.fr/sharing-layer/Patient.ndjson")]),
+            "structuredProperties": NS(properties=[
+                _sp("fr.aphp.healthdcat.accessUrl", "https://s3.aphp.fr/sharing-layer/Patient.ndjson"),
+                _sp("fr.aphp.healthdcat.distributionStatus", "COMPLETED"),
+            ]),
         },
         SAMPLE_URN: {
             "datasetProperties": NS(name="Patient_sample.ndjson", description="Echantillon FHIR Patient", externalUrl=None, created=None, lastModified=None),
@@ -171,7 +176,8 @@ _DECLARED_QUALIFIED_NAMES = [
     "fr.aphp.healthdcat.provenance", "fr.aphp.healthdcat.purpose", "fr.aphp.healthdcat.contactPointName",
     "fr.aphp.healthdcat.contactPointEmail", "fr.aphp.healthdcat.contactPointUrl", "fr.aphp.healthdcat.license",
     "fr.aphp.healthdcat.numberOfRecords", "fr.aphp.healthdcat.publishingFrequency", "fr.aphp.healthdcat.accessUrl",
-    "fr.aphp.healthdcat.referenceSpecification",
+    "fr.aphp.healthdcat.referenceSpecification", "fr.aphp.healthdcat.isReferencedBy",
+    "fr.aphp.healthdcat.distributionStatus",
     "fr.aphp.healthdcat.publisherName", "fr.aphp.healthdcat.publisherHomepage", "fr.aphp.healthdcat.publisherEmail",
     "fr.aphp.healthdcat.publisherType", "fr.aphp.healthdcat.publisherNote", "fr.aphp.healthdcat.trustedDataHolder",
     "fr.aphp.healthdcat.hdabName", "fr.aphp.healthdcat.hdabHomepage", "fr.aphp.healthdcat.hdabEmail",

--- a/tests/unit/test_mapping_dataset.py
+++ b/tests/unit/test_mapping_dataset.py
@@ -11,7 +11,7 @@ from rdflib import RDF, XSD, Literal
 
 from dh_healthdcat.mapping import vocabularies as v
 from dh_healthdcat.mapping.dataset import dataset_to_graph
-from dh_healthdcat.mapping.namespaces import CSVW, HEALTHDCATAP
+from dh_healthdcat.mapping.namespaces import CSVW, DCT, HEALTHDCATAP
 from dh_healthdcat.model import (
     Agent,
     Column,
@@ -81,7 +81,7 @@ def _fully_conformant_dataset() -> HealthDataset:
         health_category=(v.HEALTH_CATEGORY.resolve("HRAD"),),
         health_theme=(v.HEALTH_THEME.resolve("health_systems"),),
         spatial=(v.COUNTRY.resolve("FRA"),),
-        issued=datetime(2019, 1, 1),
+        issued=date(2019, 1, 1),
         modified=datetime(2026, 8, 1),
         accrual_periodicity=v.FREQUENCY.resolve("DAILY"),
         number_of_records=1_000_000_000,
@@ -199,6 +199,17 @@ def test_no_tablegroup_when_no_asset_carries_a_schema():
 
     assert list(graph.objects(None, HEALTHDCATAP.hasVariables)) == []
     assert list(graph.subjects(RDF.type, CSVW.TableGroup)) == []
+
+
+def test_issued_is_emitted_as_xsd_date_not_datetime():
+    """`fr.aphp.healthdcat.issued` est un `date` : on émet `dct:issued` en
+    `xsd:date`, pas en `xsd:dateTime` forcé. `dct:modified` reste un vrai
+    horodatage (`xsd:dateTime`)."""
+
+    dataset = _fully_conformant_dataset()
+    graph = dataset_to_graph(dataset)
+
+    assert list(graph.objects(None, DCT.issued)) == [Literal(date(2019, 1, 1), datatype=XSD.date)]
 
 
 def test_distribution_requires_stricter_fields_than_sample():

--- a/tests/unit/test_reader_dataproduct.py
+++ b/tests/unit/test_reader_dataproduct.py
@@ -42,6 +42,34 @@ def test_reference_specification_codes_resolve_to_canonical_uris_local_fallback_
     assert not [i for i in dataset.issues if i.datahub_field == "fr.aphp.healthdcat.referenceSpecification"]
 
 
+def test_bare_dois_in_is_referenced_by_are_normalised_to_https_doi_org():
+    """`fr.aphp.healthdcat.isReferencedBy` : un DOI nu (`10.x/...`) ou préfixé
+    `doi:` devient `https://doi.org/...` ; une URL déjà complète passe telle
+    quelle (`dct:isReferencedBy` attend une IRI)."""
+
+    ctx = build_context()
+    dataset = read_data_product(ctx, DATAPRODUCT_URN)
+
+    assert dataset.is_referenced_by == (
+        "https://doi.org/10.1234/abcd.2019",
+        "https://doi.org/10.5555/xyz",
+        "https://hal.science/hal-04",
+    )
+
+
+def test_distribution_status_is_resolved_to_publications_office_uri():
+    """`fr.aphp.healthdcat.distributionStatus` (COMPLETED/WITHDRAWN) est résolu
+    en IRI `.../distribution-status/*` et porté par `Distribution.status_uri`
+    (émis en `adms:status`). Sans ce câblage, la propriété était définie mais
+    jamais émise."""
+
+    ctx = build_context()
+    dataset = read_data_product(ctx, DATAPRODUCT_URN)
+
+    distribution = next(d for d in dataset.distributions if d.source_urn == ASSET_URN)
+    assert distribution.status_uri == "http://publications.europa.eu/resource/authority/distribution-status/COMPLETED"
+
+
 def test_type_coercion_warns_but_does_not_fail():
     ctx = build_context()
     dataset = read_data_product(ctx, DATAPRODUCT_URN)


### PR DESCRIPTION
Closes #7 — carte wayfinder #1, `consolidation-todo` §C.4 / §C.5 / §C.7. Basée sur `main` (post #13/#14).

## Trois corrections

**`issued` (§C.4)** — `HealthDataset.issued` : `datetime` → `date` (le SP `fr.aphp.healthdcat.issued` *est* un `date`). Le reader ne l'upcaste plus en `datetime` (`datetime.combine` retiré) ; `mapping/dataset.py` émet `dct:issued` en `xsd:date`, plus `xsd:dateTime` forcé. `dct:modified` reste un vrai horodatage.

**`isReferencedBy` (§C.5)** — nouveau `_doi_to_uri()` dans `reader/dataproduct.py` : un DOI nu (`10.x/…`) ou préfixé `doi:` → `https://doi.org/…` ; URL déjà complète ou autre URN → inchangé.

**`distributionStatus` (§C.7)** — le SP `fr.aphp.healthdcat.distributionStatus` n'était **jamais lu** (propriété définie mais non émise). Nouveau `mapping/vocab/DistributionStatus.yml` (`COMPLETED`/`WITHDRAWN` → NAL `.../distribution-status/*`) ; `reader/dataset.py` le lit via `resolve_or_warn` ; une dépréciation DataHub écrase en `WITHDRAWN`.

## Tests

3 tests (un par item) aux seams `dataset_to_graph` / `read_data_product` ; fixture `fake_datahub.py` étendue. `uv run pytest` : 107 au vert. `pyshacl` conforme (`:DateOrDateTimeDataType_Shape` accepte `xsd:date` ; `adms:status`/`dct:isReferencedBy` = `BlankNodeOrIRI`).

## Note

Le `DistributionStatus.yml` (4ᵉ fichier vocab d'auteur) + les entrées `docs/mapping.md` / `vocab/README.md` sont inclus.