### PR TITLE
docs: ADR 0001 — politique d'émission des SP HealthDCAT-AP + CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,61 @@
+# datahub-healthdcat-ap-exporter
+
+Traduit les métadonnées d'un catalogue DataHub en RDF HealthDCAT-AP, pour un fichier
+Turtle ou l'API du Catalogue de métadonnées du Health Data Hub (HDH).
+
+## Langage
+
+### Côté DataHub
+
+**DataProduct**:
+L'entité DataHub qui devient un `dcat:Dataset`. La racine de chaque graphe produit.
+_Avoid_: dataset (réservé à `dcat:Dataset`), jeu de données
+
+**Asset**:
+Un Dataset DataHub membre d'un DataProduct. Devient une `dcat:distribution`, ou un
+`adms:sample` s'il porte le tag `dcat:sample`.
+_Avoid_: distribution (c'est la sortie, pas la source), fichier
+
+**Structured property (SP)**:
+Un champ typé `fr.aphp.healthdcat.*` porté par un DataProduct ou un asset, contenant une
+valeur HealthDCAT-AP (code de vocabulaire, date, texte). Seule forme d'extension fiable
+avec le connecteur d'ingestion AP-HP.
+_Avoid_: custom property, propriété personnalisée, tag
+
+### Côté HealthDCAT-AP / RDF
+
+**Modèle pivot**:
+Les dataclasses (`HealthDataset`, `Distribution`, …) qui portent uniquement des valeurs
+déjà résolues, entre le reader DataHub et le mapping RDF. Ne connaît ni DataHub ni RDF.
+_Avoid_: DTO, représentation intermédiaire, modèle interne
+
+**Vocabulaire d'auteur**:
+Un fichier `mapping/vocab/*.yml` écrit par ce projet (pas repris du HDH), mappant des
+codes courts vers des URIs d'autorité.
+_Avoid_: custom vocab, vocabulaire local
+
+**Vocabulaire vendu**:
+Un fichier `mapping/vocab/*.yml` copié verbatim des dictionnaires du Catalogue HDH. En cas
+de divergence, le HDH fait foi.
+_Avoid_: vocabulaire importé, vocabulaire miroir
+
+**HDAB**:
+Health Data Access Body au sens EHDS ; porté par `healthdcatap:hdab`.
+_Avoid_: organisme d'accès, autorité EHDS
+
+### Profils & validation
+
+**Sensitivity shape**:
+`shapes/ehds/hdap-validator-sensitivity-shape.ttl` — la shape SHACL qu'applique le
+validateur du Catalogue HDH (profil EHDS données sensibles). C'est la porte du CI.
+_Avoid_: shape HDH, fichier SHACL, validateur
+
+**R7**:
+HealthDCAT-AP Release 7 (brouillon EC, 2026-05), le profil cible « officiel ». Sa SHACL
+diverge de la sensitivity shape sur ~30 termes.
+_Avoid_: profil officiel, spec EC
+
+**Écart R7 résiduel**:
+Un endroit où la sortie satisfait la sensitivity shape (donc le CI) mais pas R7, écart
+accepté délibérément et consigné (voir `docs/adr/`).
+_Avoid_: divergence, non-conformité, bug

--- a/docs/adr/0001-exporter-healthdcat-sp-emission.md
+++ b/docs/adr/0001-exporter-healthdcat-sp-emission.md
@@ -1,0 +1,62 @@
+# Politique d'émission des structured properties HealthDCAT-AP côté exporteur
+
+Status: accepted
+
+Source amont des arbitrages : ADR-0005 (`docs/adr/0005-healthdcat-sp-coverage-audit.md`)
+du dépôt `datahub-data-gov-registry`. Le présent ADR ne couvre que les suites
+d'implémentation côté `datahub-healthdcat-ap-exporter`.
+
+## 1. Dérivation de `healthdcatap:hasStructuredData` et `healthdcatap:hasVariables`
+
+`hasStructuredData` (booléen, `1..1` en R7) est **dérivé**, pas saisi : `true` ssi au
+moins un asset du DataProduct porte un `schemaMetadata` DataHub (⇒ une `csvw:Table`
+construite par le reader). Il est **toujours émis**, `false` compris.
+`hasVariables` est émis ssi `hasStructuredData` est vrai : un `csvw:TableGroup` au niveau
+`dcat:Dataset` regroupe par `csvw:table` toutes les `csvw:Table` (distributions et
+échantillons confondus).
+
+Alternative écartée : porter ces deux propriétés par des structured properties saisies à
+la main — rejetée car l'information existe déjà dans `schemaMetadata` et serait redondante
+ou divergente.
+
+Conséquences (écarts R7 résiduels, voir _Reporté_) :
+
+- le proxy « `schemaMetadata` présent avec ≥ 1 champ » est plus étroit que la notion R7
+  « contient des données structurées » — un CSV sans schéma enregistré est émis `false` ;
+- le sous-arbre `csvw:TableGroup → csvw:Table → csvw:Column` n'est vérifié par aucun
+  validateur : le validateur du Catalogue HDH cible `csvw:Table` / `csvw:Column` en
+  isolation (`targetClass`), pas via `hasVariables`, et R7 n'est pas dans le CI ;
+- `:CSVWColumnShape` (R7) exige `dct:description` par colonne ; l'exporteur ne l'émet que
+  si la colonne en porte une dans `schemaMetadata`.
+
+## 2. Politique d'URI `dct:conformsTo` / `referenceSpecification`
+
+Un vocabulaire d'auteur `mapping/vocab/ReferenceSpecification.yml` mappe les codes de
+`fr.aphp.healthdcat.referenceSpecification` vers des URIs canoniques : `HL7-FHIR-R4` →
+`http://hl7.org/fhir/4.0.1` (version épinglée, pas l'étiquette mouvante `R4`),
+`OMOP-CDM-5.4` → la page GitHub Pages OHDSI versionnée, `HL7v2` → `urn:hl7-org:v2xml`
+(namespace XML officiel HL7 v2). Tout code hors vocabulaire — `OSIRIS` et tout code futur
+non mappé — retombe **silencieusement** sur `urn:aphp:conformsTo:<code>`, cohérent avec le
+traitement de `spatialCoverage`.
+
+Conséquence : « canonique » est en partie aspirationnel — `OMOP-CDM-5.4` pointe une page
+HTML et `HL7v2` un URN non déréférençable, faute de mieux publié.
+
+## 3. URIs des vocabulaires HealthDCAT-AP non encore publiés
+
+`healthCategory`, `healthTheme` (et, dans le même esprit, `publisherType`) utilisent le
+namespace SEMIC `http://healthdataportal.eu/resource/authority/...`. Aucun vocabulaire
+officiel EC/HDH n'est publié pour ces termes à ce jour : ces IRI **ne sont pas
+déréférençables**. On préfère un identifiant SEMIC à l'hôte de développement en dur
+(`http://13.81.34.152:1101/...`) hérité des sources HDH. Le validateur HDH n'exige qu'une
+IRI (`sh:nodeKind sh:BlankNodeOrIRI`, aucun `sh:in`) — aucun impact fonctionnel.
+Resynchroniser ces fichiers à la publication du vocabulaire officiel.
+
+## Reporté
+
+- **`trustedDataHolder`** (§E.1) : la SP est conservée uniquement parce que le validateur
+  HDH l'exige (`:HealthPublisherAgent_Shape`, `sh:minCount 1`) ; le terme a été retiré de
+  HealthDCAT-AP côté EC (brouillon SEMIC). La retirer dès que le validateur HDH s'alignera
+  sur R7.
+- **Revalidation R8** (§E.3) : revalider l'ensemble de la table des obligations et des
+  décisions ci-dessus à la sortie de HealthDCAT-AP Release 8 (~2026-09).


### PR DESCRIPTION
Closes #8 — **dernier ticket** de la carte wayfinder #1. Docs seulement.

## `docs/adr/0001-exporter-healthdcat-sp-emission.md`

`Status: accepted`. Renvoie à l'ADR-0005 du dépôt `datahub-data-gov-registry` (arbitrages amont). Consigne 4 décisions déjà prises et implémentées via la carte :

1. **Dérivation** de `hasStructuredData` / `hasVariables` — dérivés de `schemaMetadata`, jamais saisis ; `hasStructuredData` toujours émis, `hasVariables` ssi vrai. Conséquences = écarts R7 résiduels.
2. **Politique d'URI `conformsTo`** — vocab d'auteur pour `HL7-FHIR-R4` / `OMOP-CDM-5.4` / `HL7v2` ; repli silencieux `urn:aphp:conformsTo:<code>` sinon.
3. **URIs de vocab non publiés** — `healthCategory` / `healthTheme` / `publisherType` sur le namespace SEMIC `healthdataportal.eu`, non déréférençable, resync à la publication officielle.
4. **Reporté** — `trustedDataHolder` (retirer quand le validateur HDH s'alignera sur R7) ; revalidation complète à la sortie de R8 (~2026-09).

## `CONTEXT.md`

Glossaire du domaine à la racine (création paresseuse) : DataProduct, asset, structured property, modèle pivot, vocabulaire d'auteur / vendu, sensitivity shape, R7, écart R7 résiduel, HDAB.

## Carte

Après merge, la carte wayfinder #1 n'a plus de ticket ouvert — **destination atteinte** : §C livré et validé, §E clos ou reporté dans cet ADR.