### PR TITLE
build: pipeline CI (lint, typecheck, couverture, dependency-review, audit)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,73 @@
+name: Audit dépendances
+
+# Veille de fond, complémentaire de la barrière PR (`ci.yml`) : rejoue
+# `pip-audit` chaque semaine contre le lockfile verrouillé. ADR-0003 / #18.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # lundi 06:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: audit-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: pip-audit (bloquant)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Installer les dépendances de dev
+        run: uv sync --frozen
+
+      - name: pip-audit
+        run: uv run pip-audit
+
+  open-issue:
+    name: Ouvrir une issue à l'échec
+    needs: audit
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Créer l'issue « dependencies » (dédoublonnée par titre)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "pip-audit : vulnérabilité connue dans les dépendances"
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |
+          gh label create dependencies \
+            --color BFD4F2 \
+            --description "Sécurité et mises à jour de dépendances" \
+            2>/dev/null || true
+
+          existing=$(gh issue list \
+            --state open --label dependencies \
+            --search "\"$TITLE\" in:title" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing déjà ouverte — rien à faire."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "$TITLE" \
+            --label dependencies \
+            --body "Le workflow \`audit.yml\` a échoué : \`pip-audit\` a trouvé au moins une vulnérabilité connue dans les dépendances verrouillées.
+
+          Détail dans les logs du run : $RUN_URL
+
+          Cette issue est dédoublonnée par titre — elle ne sera pas rouverte tant qu'elle reste ouverte."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,68 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+# permissions minimales par défaut ; chaque job élève ce dont il a besoin
+# (ADR-0003 / #20).
+permissions: {}
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Tests (Python ${{ matrix.python-version }})
+  lint:
+    name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Installer les dépendances de dev
+        run: uv sync --frozen
+
+      - name: ruff check
+        run: uv run ruff check .
+
+      - name: ruff format --check
+        run: uv run ruff format --check .
+
+      - name: pip-audit (advisory)
+        continue-on-error: true
+        run: uv run pip-audit
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.12"
+
+      - name: Installer les dépendances de dev
+        run: uv sync --frozen
+
+      - name: mypy --strict
+        run: uv run mypy src/dh_healthdcat
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # upload Codecov OIDC, sans token (#18)
     strategy:
       fail-fast: false
       matrix:
@@ -30,15 +81,25 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Installer le projet et ses dépendances de dev
+      - name: Installer les dépendances de dev
         run: uv sync --frozen
 
-      - name: Lancer la suite de tests
-        run: uv run pytest
+      - name: pytest + couverture
+        run: uv run pytest --cov=dh_healthdcat --cov-report=xml
+
+      - name: Upload couverture vers Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: ./coverage.xml
+          fail_ci_if_error: true
 
   build:
-    name: Construction du wheel et fumée sur installation non-éditable
+    name: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -75,3 +136,19 @@ jobs:
           assert result.conforms
           print('Données embarquées (vocab + shapes SHACL) chargées avec succès.')
           "
+
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Revue des dépendances de la PR
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          # Projet Apache-2.0 : refuse l'entrée de dépendances sous copyleft fort.
+          deny-licenses: "GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 *.egg-info/
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 *.ttl.out
 .dh-healthdcat-state.json

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Barrière de couverture (ADR-0003 / #18).
+# - project: auto → anti-régression sans chiffre magique (bloquant).
+# - patch: 80% → le code neuf d'une PR doit être couvert (bloquant).
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  - "tests/**"


### PR DESCRIPTION
PR 2 de la mise en œuvre #29. Décisions : ADR-0003, résolutions de #18 et #20.

## Contenu

### `.github/workflows/ci.yml` — barrière PR
`permissions: {}` en tête, élévation minimale par job. Jobs parallèles, sans `needs`, `fail-fast: false` :

| Job (= nom du check) | Python | Contenu | `permissions` |
|---|---|---|---|
| `lint` | 3.12 | `ruff check` + `ruff format --check` + `pip-audit` (advisory, `continue-on-error`) | `contents: read` |
| `typecheck` | 3.12 | `mypy --strict src/dh_healthdcat` | `contents: read` |
| `test` | 3.10 / 3.11 / 3.12 | `pytest --cov` ; upload Codecov depuis le **seul leg 3.12** | `contents: read` + `id-token: write` |
| `build` | 3.12 | inchangé (wheel + fumées CLI / données embarquées) | `contents: read` |
| `dependency-review` | — | `on: pull_request` ; `fail-on-severity: high` + refus du copyleft fort (GPL/AGPL, projet Apache-2.0) | `contents: read` |

### `.github/workflows/audit.yml` — veille de fond
Cron **lundi 06:00 UTC** + `workflow_dispatch`. `uv run pip-audit` **bloquant** contre le lockfile. À l'échec, un job `issues: write` ouvre une issue `dependencies` **dédoublonnée par titre**.

### `codecov.yml`
`project: auto` (anti-régression) + `patch: 80%`, **tous deux bloquants** ; `ignore: tests/**`. Couverture de référence locale : **81 %** (107 tests).

## Écarts assumés vs. les résolutions

- **`id-token: write` sur `test`** : la table de #20 donnait `contents: read` pour ce job, mais #18 tranche « Codecov **OIDC** sans token ». L'OIDC exige `id-token: write` — ajouté avec commentaire. C'est le seul écart à la table des permissions.
- **Noms de checks** courts (`lint`, `typecheck`, `test (3.10)`…, `build`, `dependency-review`) pour coller à la liste du ruleset #27, plutôt que les libellés FR descriptifs de l'ancien `ci.yml`.
- **`deny-licenses`** : liste GPL/AGPL explicite (les résolutions demandaient « un contrôle de licence » sans détailler).

## ⚠️ Prérequis pour que la CI de cette PR passe

**L'app Codecov doit être activée sur le dépôt** (item « Activer l'app Codecov » de #29). Sans elle, l'étape *Upload Codecov* du leg `test (3.12)` échoue (`fail_ci_if_error: true`). `audit.yml` ne tourne pas sur cette PR (schedule / dispatch only).

## Vérifications locales

- `ruff check` / `mypy --strict` : clean (inchangés depuis #31)
- `pytest --cov=dh_healthdcat` : 107 passed, `coverage.xml` produit, **81 %**
- `yaml.safe_load` des 3 fichiers : OK

## Suite

- Bump `setuptools` (PYSEC-2026-3447) — `pip-audit` le remonte ; sans effet ici (`lint` advisory) mais **`audit.yml` échouera au 1ᵉʳ run** et ouvrira une issue `dependencies`. À traiter avec PR 4 (Dependabot) ou un `build(deps)` dédié.
- Après un run vert : ajouter les 7 checks au ruleset `main` (#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)