### PR TITLE
build: mises à jour de dépendances automatisées (Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
+    labels: ["dependencies"]
+    assignees: ["davidouagne"]
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns: ["*"]
+      prod-minor-patch:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    labels: ["dependencies", "github-actions"]
+    assignees: ["davidouagne"]
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+# Auto-merge des PR Dependabot (ADR-0003 / #24) : patch partout, minor pour
+# les dépendances de dev uniquement. `gh pr merge --auto` attend que les
+# checks requis soient verts et ne contourne aucune règle de branche.
+on: pull_request
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Métadonnées Dependabot
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Activer l'auto-merge
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+          steps.meta.outputs.dependency-type == 'direct:development')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
PR 4 de la mise en œuvre #29. Applique **ADR-0003** / résolution de #24.

## Contenu

### `.github/dependabot.yml`
| Écosystème | Cadence | Limite | Groupes |
|---|---|---|---|
| `uv` (`/`) | hebdo lundi | 5 | `dev-dependencies` (tout le dev, 1 PR), `prod-minor-patch` (bumps prod non-majeurs, 1 PR) |
| `github-actions` (`/`) | hebdo lundi | 5 | `actions` (toutes les Actions, 1 PR) |

- Fenêtre alignée sur le cron `audit.yml` (lundi). **Majors prod** hors groupe → PR individuelles à revue humaine.
- `commit-message.prefix: "build"` + `include: "scope"` → `build(deps): …` / `build(deps-dev): …` (dans le `type-enum` de #19 ; commits signés `dependabot[bot]` → `dco` OK).
- `cooldown.default-days: 3` — évite d'auto-merger une release yankée.
- `labels: [dependencies]` (+ `github-actions`), `assignees: [davidouagne]`. Les deux labels ont été créés sur le dépôt.

### `.github/workflows/dependabot-auto-merge.yml`
`on: pull_request`, `if: github.actor == 'dependabot[bot]'`. `permissions: {}` en tête ; `contents: write` + `pull-requests: write` sur le job (table #20).

`dependabot/fetch-metadata@v2` → `gh pr merge --auto --merge` si :
- `update-type == version-update:semver-patch` (tous écosystèmes), **ou**
- `update-type == version-update:semver-minor` **et** `dependency-type == direct:development`.

Minors prod et tous les majors → revue humaine. `--auto` attend les checks requis verts et ne contourne aucune règle de branche.

## Prérequis dépôt (checklist #27, à faire avant que l'auto-merge soit effectif)
- **« Allow auto-merge »** activé sur le dépôt.
- **« Allow GitHub Actions to create and approve pull requests »** activé.
- La protection de `main` **n'exige aucune revue humaine** ni CODEOWNERS (sinon `GITHUB_TOKEN` ne peut pas satisfaire la règle → auto-merge cassé).
- Dependabot *security updates* restent **désactivées** (#20) — couverture via `audit.yml` + version-updates groupés.

## Notes
- Fichiers disjoints de #33/#34 — pas de dépendance d'ordre de merge.
- `dependabot.yml` prend effet dès le merge sur `main` (Dependabot le lit là). Le workflow d'auto-merge, lui, ne s'exécute que sur les PR ouvertes par `dependabot[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)