### PR TITLE
fix: éviter l'auto-annulation de commit-policy.yml

### DIFF
--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -12,7 +12,9 @@ on:
 permissions: {}
 
 concurrency:
-  group: commit-policy-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # `github.event_name` dans la clé : sinon les déclencheurs pull_request et
+  # pull_request_target partagent le même groupe et s'annulent mutuellement.
+  group: commit-policy-${{ github.event_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`commit-policy.yml` (mergé en #34) définit `on: [pull_request, pull_request_target]` mais une clé de `concurrency` basée sur `github.workflow` uniquement. Les deux déclencheurs partagent donc le **même groupe** : le run `pull_request_target` (job `pr-title`) annule le run `pull_request` (jobs `dco` / `commitlint`), qui remontent alors en échec.

Observé sur PR #35 : `dco` et `commitlint` en `X` avec *« Canceling since a higher priority waiting request … exists »*.

**Correctif** : ajouter `github.event_name` à la clé de `concurrency` pour isoler les deux déclencheurs.

À merger avant #35 (dont la CI est bloquée par ce bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)