### PR TITLE
fix: tolérer les corps de commit longs de Dependabot dans commitlint

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -13,5 +13,11 @@ export default {
     'header-max-length': [2, 'always', 72],
     // Scopes libres : aucune liste imposée.
     'scope-enum': [0],
+    // Corps auto-générés (Dependabot : tableaux markdown + URLs de comparaison)
+    // dépassent 100 caractères par ligne. La longueur de ligne du corps / pied
+    // n'est pas une contrainte de l'ADR-0002, et #24 interdit un `if:` excluant
+    // dependabot/* des checks — la config doit donc les tolérer.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 };


### PR DESCRIPTION
## Problème (PR #37)

La PR Dependabot #37 (`build(deps): Bump the actions group with 6 updates`) échoue sur `commitlint` :

```
✖  body's lines must not be longer than 100 characters [body-max-line-length]
```

`commitlint.config.mjs` étend `@commitlint/config-conventional`, qui impose `body-max-line-length: 100`. Le corps des commits Dependabot est **auto-généré** (tableau markdown des updates + URLs de comparaison `vX...vY`) et dépasse 100 caractères par ligne. → **toute PR Dependabot groupée à ≥ 2 updates** échoue `commitlint`.

## Correctif

`commitlint.config.mjs` : `body-max-line-length` et `footer-max-line-length` → `[0]` (désactivées).

- Ces règles sont **cosmétiques** et ne figurent pas dans ADR-0002 (qui liste `type-enum`, `header-max-length`, `subject-*`, DCO).
- #24 **interdit** un `if:` excluant `dependabot/*` des checks → c'est la config qui doit tolérer ces corps.
- `header-max-length: 72` (la vraie contrainte de sujet) **reste actif**.

## Après merge

`commitlint` de #37 repassera vert (il faut *Update branch* ou re-run sur #37 pour qu'il rejoue avec la config de `main`). #37 redevient alors une revue manuelle normale des 6 bumps majeurs — comportement voulu (majeurs non auto-mergés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)