### PR TITLE
chore: décomposer les fonctions de mapping trop complexes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,6 @@ ignore = [
     # l'interface. Regrouper en dataclass n'apporterait rien ici.
     "PLR0913",
     "PLR0917",
-    # Complexité (branches / statements) : `dataset_to_graph` et
-    # `read_data_product` sont volumineuses par nature. Décomposition suivie
-    # hors de cette PR d'outillage — voir issue #32.
-    "PLR0912",
-    "PLR0915",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/dh_healthdcat/mapping/dataset.py
+++ b/src/dh_healthdcat/mapping/dataset.py
@@ -53,7 +53,10 @@ def _missing(dataset: HealthDataset, rdf_property: str, datahub_field: str) -> N
 def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Graph:
     """Traduit un HealthDataset en graphe rdflib. `dataset.issues` est enrichi
     en place ; l'appelant décide quoi faire d'un graphe avec des erreurs
-    (le CLI export-file s'arrête avant écriture, cf. P0-5/P0-6)."""
+    (le CLI export-file s'arrête avant écriture, cf. P0-5/P0-6).
+
+    Le corps est découpé en `_add_*` par bloc de propriétés : chacun ajoute ses
+    triples et journalise ses champs obligatoires absents via `_missing`."""
 
     graph = graph if graph is not None else Graph()
     bind_prefixes(graph)
@@ -62,7 +65,22 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     graph.add((uri, RDF.type, DCAT.Dataset))
     graph.add((uri, RDF.type, DCAT.Resource))
 
-    # --- Champs obligatoires : dct:identifier, dct:title, dct:description ---
+    _add_mandatory_core(graph, uri, dataset)
+    _add_classification(graph, uri, dataset)
+    _add_agents(graph, uri, dataset)
+    _add_provenance_and_purpose(graph, uri, dataset)
+    _add_health_coverage(graph, uri, dataset)
+    _add_optional_metadata(graph, uri, dataset)
+    _add_quantitative_metadata(graph, uri, dataset)
+    _add_semantic_and_legal(graph, uri, dataset)
+    _add_distributions(graph, uri, dataset)
+
+    return graph
+
+
+def _add_mandatory_core(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """dct:identifier / title / description (+ dct:alternative optionnel)."""
+
     graph.add((uri, DCT.identifier, Literal(dataset.identifier, datatype=XSD.anyURI)))
     if dataset.title:
         graph.add((uri, DCT.title, Literal(dataset.title, lang="fr")))
@@ -76,31 +94,31 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     if dataset.acronym:
         graph.add((uri, DCT.alternative, Literal(dataset.acronym)))
 
-    # --- dcat:keyword (>=1) ---
+
+def _add_classification(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """dcat:keyword / theme, dct:type / accessRights / language,
+    dcatap:applicableLegislation."""
+
     for kw in dataset.keywords:
         graph.add((uri, DCAT.keyword, Literal(kw)))
     if not dataset.keywords:
         _missing(dataset, "dcat:keyword", "globalTags / glossaryTerms (DataProduct)")
 
-    # --- dcat:theme (>=1, IRI) ---
     for theme in dataset.theme:
         graph.add((uri, DCAT.theme, URIRef(theme)))
     if not dataset.theme:
         _missing(dataset, "dcat:theme", "fr.aphp.healthdcat.theme")
 
-    # --- dct:type (=1) ---
     if dataset.dataset_type:
         graph.add((uri, DCT.type, URIRef(dataset.dataset_type)))
     else:
         _missing(dataset, "dct:type", "fr.aphp.healthdcat.datasetType")
 
-    # --- dct:accessRights (=1) ---
     if dataset.access_rights:
         graph.add((uri, DCT.accessRights, URIRef(dataset.access_rights)))
     else:
         _missing(dataset, "dct:accessRights", "fr.aphp.healthdcat.accessRights")
 
-    # --- dcatap:applicableLegislation (>=1, IRI) ---
     for legislation in dataset.applicable_legislation:
         graph.add((uri, DCATAP.applicableLegislation, URIRef(legislation)))
     if not dataset.applicable_legislation:
@@ -111,7 +129,10 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     for lang in dataset.language:
         graph.add((uri, DCT.language, URIRef(lang)))
 
-    # --- Agents ---
+
+def _add_agents(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """dct:publisher / creator, healthdcatap:hdab, dcat:contactPoint."""
+
     if dataset.publisher:
         agent_mapping.add_publisher(
             graph, uri, dataset.publisher, dataset.source_urn, dataset.title, dataset.issues
@@ -144,7 +165,10 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
             dataset, "dcat:contactPoint", "fr.aphp.healthdcat.contactPointName/.contactPointEmail"
         )
 
-    # --- dct:provenance (>=1) ---
+
+def _add_provenance_and_purpose(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """dct:provenance → dct:ProvenanceStatement, dpv:hasPurpose → dpv:Purpose."""
+
     if dataset.provenance:
         prov_node = node_uri("provenance", dataset.source_urn)
         graph.add((uri, DCT.provenance, prov_node))
@@ -153,7 +177,6 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     else:
         _missing(dataset, "dct:provenance", "fr.aphp.healthdcat.provenance")
 
-    # --- dpv:hasPurpose (>=1) ---
     if dataset.purpose:
         purpose_node = node_uri("purpose", dataset.source_urn)
         graph.add((uri, DPV.hasPurpose, purpose_node))
@@ -162,7 +185,10 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     else:
         _missing(dataset, "dpv:hasPurpose", "fr.aphp.healthdcat.purpose")
 
-    # --- healthdcatap:healthCategory / healthTheme (>=1 chacun) ---
+
+def _add_health_coverage(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """healthdcatap:healthCategory / healthTheme, dct:spatial (>=1 chacun)."""
+
     for category in dataset.health_category:
         graph.add((uri, HEALTHDCATAP.healthCategory, URIRef(category)))
     if not dataset.health_category:
@@ -173,13 +199,15 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
     if not dataset.health_theme:
         _missing(dataset, "healthdcatap:healthTheme", "fr.aphp.healthdcat.healthTheme")
 
-    # --- dct:spatial (>=1) ---
     for spatial in dataset.spatial:
         graph.add((uri, DCT.spatial, URIRef(spatial)))
     if not dataset.spatial:
         _missing(dataset, "dct:spatial", "fr.aphp.healthdcat.spatialCoverage")
 
-    # --- Champs recommandés / optionnels, sans exigence de cardinalité minimale ---
+
+def _add_optional_metadata(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """Champs recommandés / optionnels, sans cardinalité minimale."""
+
     if dataset.issued:
         graph.add((uri, DCT.issued, Literal(dataset.issued, datatype=XSD.date)))
     if dataset.modified:
@@ -208,55 +236,37 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
             dataset.source_urn + "|retention",
         )
 
-    if dataset.number_of_records is not None:
-        graph.add(
-            (
-                uri,
-                HEALTHDCATAP.numberOfRecords,
-                Literal(dataset.number_of_records, datatype=XSD.nonNegativeInteger),
-            )
-        )
-    if dataset.number_of_unique_individuals is not None:
-        graph.add(
-            (
-                uri,
-                HEALTHDCATAP.numberOfUniqueIndividuals,
-                Literal(dataset.number_of_unique_individuals, datatype=XSD.nonNegativeInteger),
-            )
-        )
-    if dataset.min_typical_age is not None:
-        graph.add(
-            (
-                uri,
-                HEALTHDCATAP.minTypicalAge,
-                Literal(dataset.min_typical_age, datatype=XSD.nonNegativeInteger),
-            )
-        )
-    if dataset.max_typical_age is not None:
-        graph.add(
-            (
-                uri,
-                HEALTHDCATAP.maxTypicalAge,
-                Literal(dataset.max_typical_age, datatype=XSD.nonNegativeInteger),
-            )
-        )
+
+def _add_quantitative_metadata(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """Dénombrements et tranches d'âge (healthdcatap, xsd:nonNegativeInteger)."""
+
+    counts = (
+        (HEALTHDCATAP.numberOfRecords, dataset.number_of_records),
+        (HEALTHDCATAP.numberOfUniqueIndividuals, dataset.number_of_unique_individuals),
+        (HEALTHDCATAP.minTypicalAge, dataset.min_typical_age),
+        (HEALTHDCATAP.maxTypicalAge, dataset.max_typical_age),
+    )
+    for predicate, value in counts:
+        if value is not None:
+            graph.add((uri, predicate, Literal(value, datatype=XSD.nonNegativeInteger)))
+
     if dataset.population_coverage:
         graph.add(
             (uri, HEALTHDCATAP.populationCoverage, Literal(dataset.population_coverage, lang="fr"))
         )
 
+
+def _add_semantic_and_legal(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """healthdcatap:hasCodingSystem, dpv:hasLegalBasis / hasPersonalData,
+    healthdcatap:hasStructuredData (toujours émis, `false` compris — R7)."""
+
     for coding in dataset.coding_system:
         graph.add((uri, HEALTHDCATAP.hasCodingSystem, URIRef(coding)))
-
     for basis in dataset.legal_basis:
         graph.add((uri, DPV.hasLegalBasis, URIRef(basis)))
-
     for pd in dataset.personal_data:
         graph.add((uri, DPV.hasPersonalData, URIRef(pd)))
 
-    # --- healthdcatap:hasStructuredData (xsd:boolean, cardinalité R7 1..1) :
-    # dérivé de la présence d'un schéma sur au moins un asset (cf.
-    # HealthDataset.has_structured_data) ; toujours émis, `false` compris. ---
     graph.add(
         (
             uri,
@@ -265,7 +275,11 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
         )
     )
 
-    # --- Distributions / échantillons ---
+
+def _add_distributions(graph: Graph, uri: URIRef, dataset: HealthDataset) -> None:
+    """dcat:distribution / adms:sample, puis healthdcatap:hasVariables →
+    csvw:TableGroup regroupant toutes les csvw:Table du dataset (R7)."""
+
     table_nodes: list[URIRef] = []
     for distribution in dataset.distributions:
         _, table_node = distribution_mapping.add_distribution(
@@ -293,16 +307,12 @@ def dataset_to_graph(dataset: HealthDataset, graph: Graph | None = None) -> Grap
             "dataProductProperties.assets marqué du tag dcat:sample (aucun trouvé)",
         )
 
-    # --- healthdcatap:hasVariables → csvw:TableGroup (R7) : regroupe par
-    # csvw:table toutes les csvw:Table du dataset. Émis ssi ≥ 1 table (⇔
-    # has_structured_data ; R7 : hasVariables interdit si hasStructuredData
-    # est faux). Le validateur HDH n'a pas de shape TableGroup et
-    # :Dataset_Shape n'est pas sh:closed — émission sans effet sur lui. ---
+    # Le validateur HDH n'a pas de shape TableGroup et :Dataset_Shape n'est pas
+    # sh:closed — l'émission est sans effet sur lui (hasVariables interdit si
+    # hasStructuredData est faux, ce qui coïncide avec « aucune table »).
     if table_nodes:
         table_group = node_uri("tablegroup", str(uri))
         graph.add((uri, HEALTHDCATAP.hasVariables, table_group))
         graph.add((table_group, RDF.type, CSVW.TableGroup))
         for table_node in table_nodes:
             graph.add((table_group, CSVW.table, table_node))
-
-    return graph

--- a/src/dh_healthdcat/mapping/distribution.py
+++ b/src/dh_healthdcat/mapping/distribution.py
@@ -61,6 +61,28 @@ def add_distribution(
     graph.add((dataset_uri, predicate, node))
     graph.add((node, RDF.type, DCAT.Distribution))
 
+    _add_distribution_properties(graph, node, distribution, dataset_name, issues)
+
+    if not distribution.is_sample:
+        _check_health_distribution_required(distribution, dataset_name, issues)
+
+    table_node = None
+    if distribution.table is not None:
+        table_node = _add_table(graph, node, distribution, distribution.table)
+
+    return node, table_node
+
+
+def _add_distribution_properties(
+    graph: Graph,
+    node: URIRef,
+    distribution: Distribution,
+    dataset_name: str,
+    issues: list[ValidationIssue],
+) -> None:
+    """Propriétés scalaires du nœud distribution/sample (dcat:accessURL exigé =1
+    par :Distribution_Shape, le reste optionnel à ce niveau)."""
+
     if distribution.title:
         graph.add((node, DCT.title, Literal(distribution.title)))
     if distribution.description:
@@ -77,14 +99,16 @@ def add_distribution(
             f"fr.aphp.healthdcat.accessUrl (Dataset {distribution.title})",
         )
 
-    if distribution.download_url:
-        graph.add((node, DCAT.downloadURL, URIRef(distribution.download_url)))
-
-    if distribution.media_type_uri:
-        graph.add((node, DCAT.mediaType, URIRef(distribution.media_type_uri)))
-
-    if distribution.status_uri:
-        graph.add((node, ADMS.status, URIRef(distribution.status_uri)))
+    # Prédicats optionnels pointant vers une IRI unique.
+    optional_iris = (
+        (DCAT.downloadURL, distribution.download_url),
+        (DCAT.mediaType, distribution.media_type_uri),
+        (ADMS.status, distribution.status_uri),
+        (DCT.format, distribution.format_uri),
+    )
+    for predicate, value in optional_iris:
+        if value:
+            graph.add((node, predicate, URIRef(value)))
 
     if distribution.issued:
         graph.add((node, DCT.issued, Literal(distribution.issued, datatype=XSD.dateTime)))
@@ -94,63 +118,64 @@ def add_distribution(
     for legislation in distribution.applicable_legislation:
         graph.add((node, DCATAP.applicableLegislation, URIRef(legislation)))
 
-    if distribution.format_uri:
-        graph.add((node, DCT.format, URIRef(distribution.format_uri)))
     if distribution.rights:
-        # dct:rights doit être sh:BlankNodeOrIRI, jamais un littéral direct —
-        # confirmé par pyshacl (NodeKindConstraintComponent) et cohérent avec
-        # dct:accessRights côté dcat:Dataset : on pointe vers un
-        # dct:RightsStatement plutôt que d'attacher le texte directement.
-        rights_node = node_uri("rights", str(node))
-        graph.add((node, DCT.rights, rights_node))
-        graph.add((rights_node, RDF.type, DCT.RightsStatement))
-        graph.add((rights_node, RDFS.label, Literal(distribution.rights, lang="fr")))
+        _add_distribution_rights(graph, node, distribution.rights)
     if distribution.byte_size is not None:
         graph.add(
             (node, DCAT.byteSize, Literal(distribution.byte_size, datatype=XSD.nonNegativeInteger))
         )
 
-    # :healthDistribution_Shape n'impose ces quatre champs qu'aux dcat:distribution,
-    # pas aux adms:sample.
-    if not distribution.is_sample:
-        if not distribution.applicable_legislation:
-            _missing(
-                issues,
-                dataset_name,
-                dataset_urn_or_source(distribution),
-                "dcatap:applicableLegislation",
-                "hérité du DataProduct — vérifier fr.aphp.healthdcat.applicableLegislation",
-            )
-        if distribution.byte_size is None:
-            _missing(
-                issues,
-                dataset_name,
-                dataset_urn_or_source(distribution),
-                "dcat:byteSize",
-                f"profil DataHub absent pour {distribution.title} (datasetProfile.sizeInBytes)",
-            )
-        if not distribution.format_uri:
-            _missing(
-                issues,
-                dataset_name,
-                dataset_urn_or_source(distribution),
-                "dct:format",
-                f"fr.aphp.healthdcat.distributionFormat (Dataset {distribution.title})",
-            )
-        if not distribution.rights:
-            _missing(
-                issues,
-                dataset_name,
-                dataset_urn_or_source(distribution),
-                "dct:rights",
-                "fr.aphp.healthdcat.license (DataProduct, hérité)",
-            )
 
-    table_node = None
-    if distribution.table is not None:
-        table_node = _add_table(graph, node, distribution, distribution.table)
+def _add_distribution_rights(graph: Graph, node: URIRef, rights: str) -> None:
+    """dct:rights doit être sh:BlankNodeOrIRI, jamais un littéral direct
+    (pyshacl NodeKindConstraintComponent) : on pointe vers un
+    dct:RightsStatement plutôt que d'attacher le texte directement."""
 
-    return node, table_node
+    rights_node = node_uri("rights", str(node))
+    graph.add((node, DCT.rights, rights_node))
+    graph.add((rights_node, RDF.type, DCT.RightsStatement))
+    graph.add((rights_node, RDFS.label, Literal(rights, lang="fr")))
+
+
+def _check_health_distribution_required(
+    distribution: Distribution, dataset_name: str, issues: list[ValidationIssue]
+) -> None:
+    """:healthDistribution_Shape impose applicableLegislation / byteSize /
+    format / rights aux `dcat:distribution` seulement, pas aux `adms:sample`."""
+
+    urn = dataset_urn_or_source(distribution)
+    if not distribution.applicable_legislation:
+        _missing(
+            issues,
+            dataset_name,
+            urn,
+            "dcatap:applicableLegislation",
+            "hérité du DataProduct — vérifier fr.aphp.healthdcat.applicableLegislation",
+        )
+    if distribution.byte_size is None:
+        _missing(
+            issues,
+            dataset_name,
+            urn,
+            "dcat:byteSize",
+            f"profil DataHub absent pour {distribution.title} (datasetProfile.sizeInBytes)",
+        )
+    if not distribution.format_uri:
+        _missing(
+            issues,
+            dataset_name,
+            urn,
+            "dct:format",
+            f"fr.aphp.healthdcat.distributionFormat (Dataset {distribution.title})",
+        )
+    if not distribution.rights:
+        _missing(
+            issues,
+            dataset_name,
+            urn,
+            "dct:rights",
+            "fr.aphp.healthdcat.license (DataProduct, hérité)",
+        )
 
 
 def dataset_urn_or_source(distribution: Distribution) -> str:

--- a/src/dh_healthdcat/reader/dataproduct.py
+++ b/src/dh_healthdcat/reader/dataproduct.py
@@ -11,6 +11,7 @@ G4/P0-6.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from dh_healthdcat.mapping import vocabularies as v
 from dh_healthdcat.mapping.vocabularies import (
@@ -135,6 +136,106 @@ def _as_uri(value: str | None, urn_namespace: str) -> str | None:
     return f"urn:{urn_namespace}:{value}"
 
 
+def _read_keywords(ctx: ReadContext, entity: SemitypedEntity) -> list[str]:
+    """Mots-clés : tags « porteurs de sens » (hors dcat:sample) + libellés des
+    glossary terms (ou leur id local à défaut de glossaryTermInfo.name)."""
+
+    keywords: list[str] = []
+    tags = entity.get("globalTags")
+    if tags:
+        for t in tags.tags:
+            local = t.tag.rsplit(":", 1)[-1]
+            if local not in ("dcat:sample",):
+                keywords.append(local)
+    glossary = entity.get("glossaryTerms")
+    if glossary:
+        for term in glossary.terms:
+            term_entity = ctx.get_entity(term.urn)
+            info = term_entity.get("glossaryTermInfo")
+            keywords.append(info.name if info and info.name else term.urn.rsplit(":", 1)[-1])
+    return keywords
+
+
+def _read_spatial(
+    ctx: ReadContext, entity: SemitypedEntity, title: str, urn: str, issues: list[ValidationIssue]
+) -> list[str]:
+    """dct:spatial : URI telle quelle, sinon code pays résolu via v.COUNTRY,
+    sinon le code brut (URI d'un autre référentiel, ou code régional FR-75)."""
+
+    spatial: list[str] = []
+    for code in props.get_strings(
+        ctx, entity, "fr.aphp.healthdcat.spatialCoverage", title, urn, issues
+    ):
+        if code.startswith("http"):
+            spatial.append(code)
+            continue
+        try:
+            spatial.append(v.COUNTRY.resolve(code))
+        except UnknownVocabularyValueError:
+            spatial.append(code)
+    return spatial
+
+
+def _read_conforms_to(
+    ctx: ReadContext, entity: SemitypedEntity, title: str, urn: str, issues: list[ValidationIssue]
+) -> list[str]:
+    """dct:conformsTo : code résolu via v.REFERENCE_SPECIFICATION, sinon
+    enveloppé en urn:aphp:conformsTo:<code> (OSIRIS & co.)."""
+
+    conforms_to: list[str] = []
+    for code in props.get_strings(
+        ctx, entity, "fr.aphp.healthdcat.referenceSpecification", title, urn, issues
+    ):
+        try:
+            conforms_to.append(v.REFERENCE_SPECIFICATION.resolve(code))
+        except UnknownVocabularyValueError:
+            fallback = _as_uri(code, "aphp:conformsTo")
+            if fallback:
+                conforms_to.append(fallback)
+    return conforms_to
+
+
+def _read_period(
+    entity: SemitypedEntity,
+    start_prop: str,
+    end_prop: str,
+    title: str,
+    urn: str,
+    issues: list[ValidationIssue],
+) -> PeriodOfTime | None:
+    """PeriodOfTime à partir d'un couple de structured properties date ;
+    None si les deux bornes sont absentes."""
+
+    start = props.get_date(entity, start_prop, title, urn, issues)
+    end = props.get_date(entity, end_prop, title, urn, issues)
+    return PeriodOfTime(start_date=start, end_date=end) if (start or end) else None
+
+
+def _read_assets(
+    ctx: ReadContext,
+    dp: Any,
+    title: str,
+    issues: list[ValidationIssue],
+    inherited_license: str | None,
+    inherited_legislation: tuple[str, ...],
+) -> tuple[list[Distribution], list[Distribution]]:
+    """Distributions / échantillons depuis dataProductProperties.assets, avec
+    héritage dct:rights et dcatap:applicableLegislation du DataProduct."""
+
+    distributions: list[Distribution] = []
+    samples: list[Distribution] = []
+    for association in dp.assets or []:
+        distribution = dataset_reader.read_distribution(
+            ctx, association.destinationUrn, association.destinationUrn, title, issues
+        )
+        if distribution.rights is None and inherited_license:
+            distribution = _with_rights(distribution, inherited_license)
+        if not distribution.applicable_legislation and inherited_legislation:
+            distribution = _with_legislation(distribution, inherited_legislation)
+        (samples if distribution.is_sample else distributions).append(distribution)
+    return distributions, samples
+
+
 def read_data_product(
     ctx: ReadContext,
     dataproduct_urn: str,
@@ -155,20 +256,7 @@ def read_data_product(
     issues: list[ValidationIssue] = []
     _warn_undeclared_properties(ctx, entity, title, dataproduct_urn, issues)
 
-    # --- Mots-clés : tags "porteurs de sens" + libellés des glossary terms ---
-    keywords: list[str] = []
-    tags = entity.get("globalTags")
-    if tags:
-        for t in tags.tags:
-            local = t.tag.rsplit(":", 1)[-1]
-            if local not in ("dcat:sample",):
-                keywords.append(local)
-    glossary = entity.get("glossaryTerms")
-    if glossary:
-        for term in glossary.terms:
-            term_entity = ctx.get_entity(term.urn)
-            info = term_entity.get("glossaryTermInfo")
-            keywords.append(info.name if info and info.name else term.urn.rsplit(":", 1)[-1])
+    keywords = _read_keywords(ctx, entity)
 
     # --- Champs structured properties, valeurs simples ---
     acronym = props.get_string(
@@ -273,31 +361,8 @@ def read_data_product(
         issues,
     )
 
-    spatial_raw = props.get_strings(
-        ctx, entity, "fr.aphp.healthdcat.spatialCoverage", title, dataproduct_urn, issues
-    )
-    spatial: list[str] = []
-    for code in spatial_raw:
-        if code.startswith("http"):
-            spatial.append(code)
-            continue
-        try:
-            spatial.append(v.COUNTRY.resolve(code))
-        except UnknownVocabularyValueError:
-            spatial.append(
-                code
-            )  # déjà une URI d'un autre référentiel (GeoNames...) ou code régional (FR-75)
-
-    conforms_to: list[str] = []
-    for code in props.get_strings(
-        ctx, entity, "fr.aphp.healthdcat.referenceSpecification", title, dataproduct_urn, issues
-    ):
-        try:
-            conforms_to.append(v.REFERENCE_SPECIFICATION.resolve(code))
-        except UnknownVocabularyValueError:
-            fallback = _as_uri(code, "aphp:conformsTo")  # OSIRIS & co. → urn:aphp:conformsTo:<code>
-            if fallback:
-                conforms_to.append(fallback)
+    spatial = _read_spatial(ctx, entity, title, dataproduct_urn, issues)
+    conforms_to = _read_conforms_to(ctx, entity, title, dataproduct_urn, issues)
     license_ = props.get_string(
         ctx, entity, "fr.aphp.healthdcat.license", title, dataproduct_urn, issues
     )
@@ -339,28 +404,21 @@ def read_data_product(
         else None
     )
 
-    temporal_start = props.get_date(
-        entity, "fr.aphp.healthdcat.temporalCoverageStart", title, dataproduct_urn, issues
+    temporal = _read_period(
+        entity,
+        "fr.aphp.healthdcat.temporalCoverageStart",
+        "fr.aphp.healthdcat.temporalCoverageEnd",
+        title,
+        dataproduct_urn,
+        issues,
     )
-    temporal_end = props.get_date(
-        entity, "fr.aphp.healthdcat.temporalCoverageEnd", title, dataproduct_urn, issues
-    )
-    temporal = (
-        PeriodOfTime(start_date=temporal_start, end_date=temporal_end)
-        if (temporal_start or temporal_end)
-        else None
-    )
-
-    retention_start = props.get_date(
-        entity, "fr.aphp.healthdcat.retentionPeriodStart", title, dataproduct_urn, issues
-    )
-    retention_end = props.get_date(
-        entity, "fr.aphp.healthdcat.retentionPeriodEnd", title, dataproduct_urn, issues
-    )
-    retention_period = (
-        PeriodOfTime(start_date=retention_start, end_date=retention_end)
-        if (retention_start or retention_end)
-        else None
+    retention_period = _read_period(
+        entity,
+        "fr.aphp.healthdcat.retentionPeriodStart",
+        "fr.aphp.healthdcat.retentionPeriodEnd",
+        title,
+        dataproduct_urn,
+        issues,
     )
 
     # --- Agents (publisher / creator / hdab) — structured properties plates sur le DataProduct ---
@@ -369,20 +427,7 @@ def read_data_product(
     hdab = agents_reader.read_hdab(ctx, entity, title, dataproduct_urn, issues)
     contact_point = agents_reader.read_contact_point(ctx, entity, title, dataproduct_urn, issues)
 
-    # --- Distributions / échantillons, depuis dataProductProperties.assets ---
-    distributions: list[Distribution] = []
-    samples: list[Distribution] = []
-    for association in dp.assets or []:
-        distribution = dataset_reader.read_distribution(
-            ctx, association.destinationUrn, association.destinationUrn, title, issues
-        )
-        # dct:rights hérité de la licence du DataProduct (:healthDistribution_Shape l'exige =1)
-        if distribution.rights is None and license_:
-            distribution = _with_rights(distribution, license_)
-        # dcatap:applicableLegislation hérité du DataProduct si l'asset n'en a pas
-        if not distribution.applicable_legislation and applicable_legislation:
-            distribution = _with_legislation(distribution, applicable_legislation)
-        (samples if distribution.is_sample else distributions).append(distribution)
+    distributions, samples = _read_assets(ctx, dp, title, issues, license_, applicable_legislation)
 
     return HealthDataset(
         source_urn=dataproduct_urn,


### PR DESCRIPTION
Closes #32.

`dataset_to_graph` (58 branches / 117 statements), `add_distribution` (19) et `read_data_product` (15 / 76) déclenchaient `PLR0912` / `PLR0915`, jusqu'ici en `ignore` **documenté** dans `[tool.ruff.lint]`.

## Décomposition (sans changement de comportement)

| Fichier | Avant | Après |
|---|---|---|
| `mapping/dataset.py` | `dataset_to_graph` monolithique | orchestrateur + 9 `_add_*` par bloc de propriétés (core, classification, agents, provenance/purpose, health coverage, optional, quantitative, semantic/legal, distributions) |
| `mapping/distribution.py` | `add_distribution` monolithique | + `_add_distribution_properties`, `_add_distribution_rights`, `_check_health_distribution_required` ; prédicats optionnels → IRI unique via une boucle |
| `reader/dataproduct.py` | `read_data_product` monolithique | + `_read_keywords`, `_read_spatial`, `_read_conforms_to`, `_read_period`, `_read_assets` |

`pyproject.toml` : **`PLR0912` et `PLR0915` retirés de l'`ignore`** — `PLR0913` / `PLR0917` (trop d'arguments) restent, par choix (la liste d'arguments nommés est l'interface).

## Garanties

- **Aucun changement de comportement** : mêmes triples RDF produits, mêmes `ValidationIssue` (les blocs gardent leur ordre ; le graphe rdflib est un ensemble, l'ordre d'`add()` est sans effet).
- `ruff check` avec `PL` complet (`PLR0912`/`PLR0915` réactivés) : **clean**.
- `mypy --strict` : clean (25 fichiers).
- **107 tests** : OK (inchangés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)