### PR TITLE
fix: signoff release-please via le fichier de config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          signoff: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          # signoff : porté par release-please-config.json (l'action v4
+          # n'expose pas cet input) — le commit chore(main): release … du bot
+          # porte ainsi un Signed-off-by et passe le check dco (ADR-0002).
 
   build:
     needs: release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "fe408fb8044f1ce02ca525838891d8f5948d6aa1",
+  "signoff": "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Problème — run `release` en échec sur `main`

Depuis le merge de #40, chaque push sur `main` fait échouer le workflow `release` (job `release-please`), pour **deux raisons** :

### 1. `signoff` n'est pas un input de `googleapis/release-please-action@v4` (corrigé ici)

```
! Unexpected input(s) 'signoff', valid inputs are ['token', 'release-type', ...]
```

L'input était **silencieusement ignoré**. Conséquence : le commit `chore(main): release X.Y.Z` du bot serait parti **sans `Signed-off-by`** → recalé par le check `dco` sur la Release PR (ADR-0002 interdit un `if:` d'exception).

**Correctif** : `signoff` déplacé dans `release-please-config.json` (clé supportée par le schéma de config de release-please). Input retiré du workflow.

### 2. « GitHub Actions is not permitted to create or approve pull requests » (réglage dépôt — à faire par toi)

```
##[error]release-please failed: GitHub Actions is not permitted to create or approve pull requests.
```

`can_approve_pull_request_reviews` est à `false` sur le dépôt. **Settings → Actions → General → Workflow permissions → cocher « Allow GitHub Actions to create and approve pull requests »** (garder « Read repository contents » ; c'est déjà dans la checklist #27, requis aussi par l'auto-merge Dependabot #24). L'API `PUT /actions/permissions/workflow` m'est refusée par le sandbox.

Une fois les deux faits, le prochain push sur `main` créera la Release PR (release-please a déjà poussé la branche `release-please--branches--main--components--dh-healthdcat` et son commit — elle sera réutilisée).

## Note bénigne

Les avertissements `commit could not be parsed: … Merge pull request #NN …` sont normaux : release-please ignore les commits de merge et se base sur les commits non-merge individuels (comportement voulu par ADR-0002 §1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)