### PR TITLE
docs: consolider les notes de recherche CI/CD sur main

### DIFF
--- a/docs/research/dependabot-uv.md
+++ b/docs/research/dependabot-uv.md
@@ -1,0 +1,241 @@
+# Dependabot & `uv` : écosystème, groupes, auto-merge (état de l'art 2026)
+
+Recherche pour la carte wayfinder #17, ticket #21. Sources primaires uniquement :
+GitHub Docs (Dependabot), GitHub Changelog, docs Astral `uv`, `dependabot/fetch-metadata`.
+
+Vérifié le 2026-08-28 contre les sources listées en fin de document.
+
+## 1. Dependabot lit-il `uv.lock` / un `pyproject.toml` géré par `uv` ?
+
+**Oui, nativement, via l'écosystème dédié `uv`.**
+
+- `package-ecosystem` correct = **`"uv"`** (et **non** `"pip"`). C'est la valeur
+  recommandée par Astral : « The package-ecosystem value for uv is `"uv"`. […]
+  Dependabot supports updating `uv.lock` files. »
+  Source : <https://docs.astral.sh/uv/guides/integration/dependabot/>
+- Dependabot met à jour **à la fois `pyproject.toml` et `uv.lock`** (manifeste + lockfile),
+  comme pour les autres écosystèmes à lockfile.
+  Source : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+- Chronologie (Changelog GitHub) :
+  - **Version updates GA** le 2025-03-13 : « For projects that use `uv` as a package
+    manager, Dependabot version updates can now ensure dependencies stay current. »
+    <https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/>
+  - **Security updates** le 2025-12-16 : « Dependabot now supports security alerts and
+    updates for uv. »
+    <https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/>
+- `uv` est traité au même rang que `pip` pour la catégorisation des dépendances : la
+  clé `groups > dependency-type` est « Supported by: `bundler`, `composer`, `mix`,
+  `maven`, `npm`, `pip`, `uv` ».
+  Source : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+
+### Limites connues (à surveiller)
+
+- Astral signale que « there are some use cases that are not yet working » et renvoie au
+  suivi <https://github.com/astral-sh/uv/issues/2512>.
+  Source : <https://docs.astral.sh/uv/guides/integration/dependabot/>
+- Si le projet fixe `exclude-newer` (cooldown côté `uv`), Astral recommande de poser un
+  **cooldown Dependabot équivalent** (`cooldown:` / `default-days`, cf. §2) sinon la
+  résolution `uv lock` échoue et la PR ne peut pas être produite.
+  Source : <https://docs.astral.sh/uv/guides/integration/dependabot/>
+- `versioning-strategy` pour `uv` : demande d'évolution ouverte
+  (<https://github.com/dependabot/dependabot-core/issues/12162>, statut « Done » dans le
+  board mais réponses mainteneurs non consultables) — vérifier le comportement `increase`
+  contre l'`options reference` avant de s'y fier.
+
+### Exemple minimal (`.github/dependabot.yml`)
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Source : <https://docs.astral.sh/uv/guides/integration/dependabot/>
+
+## 2. `groups` — regrouper les mises à jour dans une seule PR
+
+Un bloc `groups` sous une entrée `updates` fusionne plusieurs bumps en **une PR par
+groupe**. Clés (options reference) :
+
+| Clé | Valeurs | Rôle |
+|-----|---------|------|
+| `applies-to` | `version-updates` (défaut) \| `security-updates` | à quel type de MAJ le groupe s'applique |
+| `dependency-type` | `development` \| `production` | filtre dev vs prod (supporté par `uv`) ; par défaut tous types |
+| `patterns` | liste, `*` en joker | noms de dépendances à inclure |
+| `exclude-patterns` | liste, `*` en joker | noms à exclure |
+| `update-types` | `major` \| `minor` \| `patch` (liste) | limite le groupe à certains niveaux semver ; par défaut tous |
+
+Source : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+
+Exemple — un groupe « toutes les dépendances de dev » + un groupe « patchs prod » :
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        patterns: ["*"]
+      prod-patches:
+        dependency-type: "production"
+        update-types: ["patch"]
+```
+
+Note 2026 : le regroupement fonctionne aussi **au travers de plusieurs écosystèmes**
+(« Single pull request for Dependabot / multi-ecosystem », GA 2025-07-01,
+<https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support/>)
+et **par nom de dépendance à travers plusieurs répertoires**
+(<https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/>).
+
+Cooldown : la clé `cooldown` (avec `default-days`, `semver-major-days`,
+`semver-minor-days`, `semver-patch-days`) est disponible et **supportée pour `uv`**.
+Source : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+
+## 3. Auto-merge : `dependabot/fetch-metadata` + `gh pr merge --auto`
+
+Mécanisme recommandé par GitHub : un workflow déclenché `on: pull_request`, filtré sur
+l'auteur `dependabot[bot]`, qui récupère les métadonnées de la PR puis active
+l'auto-merge natif de GitHub.
+
+```yaml
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@<pin-sha>
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Source : <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>
+
+Sorties utiles de `fetch-metadata` pour les conditions :
+`update-type` (`version-update:semver-patch|minor|major`), `dependency-type`
+(`direct:production`, `direct:development`, `indirect`), `dependency-names`.
+Source : <https://github.com/dependabot/fetch-metadata>
+
+### Interaction avec la protection de branche
+
+- `gh pr merge --auto` **ne contourne rien** : GitHub ne fusionne que lorsque **toutes
+  les conditions de la branche protégée sont vertes** (checks requis, revues requises,
+  conversations résolues…). Il faut donc activer « Allow auto-merge » sur le dépôt et
+  « Require status checks to pass before merging » sur la branche cible.
+  Source : <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>
+- **`GITHUB_TOKEN` est en lecture seule** pour les runs déclenchés par Dependabot sur les
+  événements `pull_request`, `push`, etc. On regagne les droits d'écriture nécessaires en
+  déclarant explicitement `permissions:` dans le workflow (`pull-requests: write` pour
+  approuver, `contents: write` pour mer.).
+  Source : <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>
+- Si la branche **exige N approbations**, ajouter une étape
+  `gh pr review --approve "$PR_URL"` (avec `pull-requests: write`). Attention : une revue
+  faite avec `GITHUB_TOKEN` (compte `github-actions[bot]`) **ne satisfait pas** une règle
+  CODEOWNERS ni « Require review from Code Owners » — il faut alors un PAT / GitHub App,
+  ou exempter Dependabot, ou retirer l'exigence de revue sur ces PR.
+- Si la branche cible utilise une **merge queue**, `GITHUB_TOKEN` ne peut pas ajouter la
+  PR à la file : PAT ou token GitHub App avec droit de merge requis.
+  Source : <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>
+- Les secrets/vars de la PR sont ceux du contexte **Dependabot** (`Settings > Secrets >
+  Dependabot`), pas ceux d'Actions, pour les runs déclenchés par Dependabot.
+
+## 4. Écosystème `github-actions` — `directory` et nouveautés 2026
+
+- Valeur `directory` : **`"/"`**. « Dependabot will search the `/.github/workflows`
+  directory, as well as the `action.yml`/`action.yaml` file from the root directory. »
+  Source : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+- Clé plurielle **`directories`** (liste ; supporte `*` et le globbing, contrairement à
+  `directory`) disponible depuis 2024-06-25 — utile pour des actions composites dans des
+  sous-dossiers.
+  Source : <https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/>
+- Nouveauté 2026-02-24 : regroupement des updates **par nom de dépendance à travers
+  plusieurs répertoires** (réduit le nombre de PR quand la même action est épinglée à
+  plusieurs endroits).
+  Source : <https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/>
+- Bonnes pratiques inchangées : épingler les actions au SHA, et grouper les bumps
+  `github-actions` (souvent bruyants) via un `groups: { actions: { patterns: ["*"] } }`.
+
+```yaml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+```
+
+## 5. Alternative Renovate (pour un dépôt `uv`)
+
+Renovate (app tierce Mend, ou self-hosted) apporte, au-delà de Dependabot : une détection
+`uv` native via le manager **`pep621`** (met à jour `pyproject.toml` **et** `uv.lock`, y
+compris `tool.uv.dev-dependencies` / `tool.uv.sources` et les uv workspaces —
+<https://docs.renovatebot.com/modules/manager/pep621/>), le **`lockFileMaintenance`** qui
+rafraîchit périodiquement tout le lockfile pour capter les transitives
+(`{"lockFileMaintenance": {"enabled": true}}`, recommandé par Astral —
+<https://docs.astral.sh/uv/guides/integration/renovate/>), un large jeu de **presets**
+partageables (`config:recommended`, `schedule:*`, `group:*`, dependency dashboard,
+`minimumReleaseAge` équivalent au cooldown), et un contrôle de regroupement /
+`packageRules` nettement plus fin. Le coût : c'est une **application tierce** à installer
+et à autoriser sur l'org (revue sécurité, permissions dépôt étendues), une courbe de
+configuration plus raide, et pour `uv.lock` des rugosités documentées (index PyPI privé
+non transmis à `uv lock --upgrade`, contamination de `lockedVersion` entre `pyproject.toml`
+— discussions renovatebot/renovate #40201, #41719). Dependabot reste « zéro install,
+intégré GitHub » ; Renovate se justifie si l'on veut le lockFileMaintenance des
+transitives et le partage de presets à l'échelle de plusieurs dépôts.
+
+## Recommandation
+
+1. Ajouter une entrée `package-ecosystem: "uv"`, `directory: "/"`, `schedule.interval:
+   "weekly"` dans `.github/dependabot.yml` — Dependabot mettra à jour `pyproject.toml` et
+   `uv.lock`. Garder l'entrée `github-actions` existante avec `directory: "/"`.
+2. Grouper : un groupe `dev-dependencies` (`dependency-type: development`, `patterns:
+   ["*"]`), un groupe `prod-minor-patch` (`update-types: ["minor","patch"]`), un groupe
+   `actions` pour `github-actions`. Laisser les `major` en PR individuelles.
+3. Auto-merge via un workflow `dependabot/fetch-metadata` + `gh pr merge --auto --merge`,
+   limité à `update-type == version-update:semver-patch` (voire `semver-minor` pour les
+   dev-deps), avec `permissions: { contents: write, pull-requests: write }`. Activer
+   « Allow auto-merge » + checks requis sur `main` ; ne pas exiger de revue humaine /
+   CODEOWNERS sur les PR Dependabot (sinon prévoir une étape `gh pr review --approve`, qui
+   ne satisfait pas CODEOWNERS avec `GITHUB_TOKEN`).
+4. Si le projet adopte `exclude-newer`, ajouter un `cooldown` Dependabot cohérent.
+5. Rester sur Dependabot (intégré, zéro install). N'envisager Renovate que si le besoin de
+   `lockFileMaintenance` (transitives) ou de presets multi-dépôts devient concret.
+
+## Sources
+
+- Astral — Using uv with Dependabot : <https://docs.astral.sh/uv/guides/integration/dependabot/>
+- Astral — Using uv with Renovate : <https://docs.astral.sh/uv/guides/integration/renovate/>
+- GitHub Docs — Dependabot options reference : <https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference>
+- GitHub Docs — Automating Dependabot with GitHub Actions : <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>
+- GitHub Docs — Dependabot supported ecosystems : <https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories>
+- GitHub — `dependabot/fetch-metadata` : <https://github.com/dependabot/fetch-metadata>
+- Changelog — Dependabot version updates support uv (GA, 2025-03-13) : <https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/>
+- Changelog — Dependabot security updates support uv (2025-12-16) : <https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/>
+- Changelog — Single PR for Dependabot / multi-ecosystem (2025-07-01) : <https://github.blog/changelog/2025-07-01-single-pull-request-for-dependabot-multi-ecosystem-support/>
+- Changelog — `directories` key + glob (2024-06-25) : <https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/>
+- Changelog — Group updates by dependency name across directories (2026-02-24) : <https://github.blog/changelog/2026-02-24-dependabot-can-group-updates-by-dependency-name-across-multiple-directories/>
+- Renovate Docs — PEP 621 manager (uv, `lockFileMaintenance`) : <https://docs.renovatebot.com/modules/manager/pep621/>
+- dependabot/dependabot-core#12162 — `versioning-strategy` pour uv : <https://github.com/dependabot/dependabot-core/issues/12162>
+- astral-sh/uv#2512 — suivi compatibilité Dependabot : <https://github.com/astral-sh/uv/issues/2512>

--- a/docs/research/pypi-trusted-publishing.md
+++ b/docs/research/pypi-trusted-publishing.md
@@ -1,0 +1,480 @@
+# PyPI Trusted Publishing + OIDC — état de l'art 2026
+
+Recherche préalable (ticket #23, wayfinder map #17) à la mise en place d'une
+publication du paquet **`dh-healthdcat`** (l'exporteur) sur PyPI depuis GitHub
+Actions, **sans token API long-lived**, via *Trusted Publishing* (OIDC), avec
+**attestations PEP 740**, build via `uv build`, déclenchement **sur tags/releases
+uniquement**.
+
+Vérifié le 2026-08-28 contre les sources primaires listées en fin de document.
+
+> **Périmètre — frontière explicite.** `actions/attest-build-provenance`
+> (attestation *SLSA build provenance* stockée dans le magasin d'attestations
+> GitHub, vérifiée par `gh attestation verify`) est **hors périmètre** de cet
+> effort. Ce document ne traite que des attestations **PEP 740** que
+> `pypa/gh-action-pypi-publish` émet **nativement** vers PyPI. Voir §5 pour la
+> distinction précise.
+
+---
+
+## 1. Ce qu'est un *Trusted Publisher*
+
+*Trusted Publishing* utilise OpenID Connect (OIDC) pour authentifier un job CI
+auprès de PyPI **sans secret partagé**. Le fournisseur d'identité (GitHub
+Actions) émet un jeton OIDC court, fortement vérifiable ; PyPI le valide contre
+la configuration déclarée et **émet en retour un token API PyPI éphémère valable
+15 minutes**, suffisant pour l'upload.
+Source : <https://docs.pypi.org/trusted-publishers/>
+
+- Fournisseurs OIDC supportés par PyPI : **GitHub Actions**, GitLab CI/CD, Google
+  Cloud, ActiveState.
+  Source : <https://docs.pypi.org/trusted-publishers/>
+- Avantage vs token API classique : les tokens API PyPI sont *long-lived* ; un
+  attaquant qui compromet un token peut l'utiliser jusqu'à révocation manuelle.
+  Le token minté par Trusted Publishing expire en 15 min.
+  Source : <https://docs.pypi.org/trusted-publishers/>
+- `pypa/gh-action-pypi-publish` documente le flux : configurer le job avec la
+  permission `id-token: write` **et sans** `user`/`password` explicites → le flux
+  Trusted Publishing s'active automatiquement.
+  Source : <https://github.com/pypa/gh-action-pypi-publish#trusted-publishing>
+
+---
+
+## 2. Setup côté PyPI
+
+### 2a. Projet déjà publié sur PyPI
+
+Sur <https://pypi.org/manage/projects/> → *Manage* sur le projet → onglet
+*Publishing* de la barre latérale → section **GitHub Actions**, remplir :
+
+| Champ PyPI | Valeur pour ce dépôt | Contrainte |
+|---|---|---|
+| *Repository owner's name* | `davidouagne` | org/compte GitHub, comparaison insensible à la casse |
+| *Repository name* | `datahub-healthdcat-ap-exporter` | idem |
+| *Workflow filename* | `release.yml` | **basename seul**, pas le chemin ; le fichier doit vivre dans `.github/workflows/` |
+| *GitHub Actions environment name* | `pypi` | **optionnel mais « strongly recommended »** — active des restrictions supplémentaires (approbation manuelle par un sous-ensemble de mainteneurs de confiance) |
+
+Cliquer *Add*.
+Source : <https://docs.pypi.org/trusted-publishers/adding-a-publisher/>
+
+### 2b. Projet pas encore créé — *pending publisher*
+
+Le projet `dh-healthdcat` n'existe pas encore sur PyPI → utiliser un **pending
+publisher** : dans les réglages **du compte** (pas d'un projet, il n'existe pas
+encore) → *Publishing* → formulaire GitHub Actions avec les **mêmes 4 champs +
+le nom de projet PyPI** (`dh-healthdcat`).
+
+- Un pending publisher **ne réserve pas le nom** tant qu'il n'a pas servi à
+  publier. Si quelqu'un d'autre enregistre ce nom avant la première publication,
+  le pending publisher est invalidé.
+- À la première publication réussie, le projet est **créé automatiquement** et le
+  pending publisher devient un trusted publisher normal.
+Source : <https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/>
+
+### 2c. Notes d'exploitation
+
+- Le *Workflow filename* est comparé **exactement** ; renommer le workflow
+  (ou le dépôt, ou le transférer) casse la publication tant que le publisher
+  PyPI n'est pas mis à jour.
+- Le champ *environment* PyPI doit correspondre **exactement** à la valeur
+  `environment:` du job GitHub Actions (voir §3).
+- On peut déclarer **plusieurs** trusted publishers sur un même projet (ex. un
+  pour `release.yml` en prod, un pour TestPyPI).
+Source : <https://docs.pypi.org/trusted-publishers/adding-a-publisher/>
+
+---
+
+## 3. Setup côté workflow GitHub Actions
+
+### 3.1 Permission `id-token: write`
+
+- **Obligatoire** pour Trusted Publishing. À déclarer **au niveau du job** de
+  publication uniquement, jamais globalement (moindre privilège ; empêche un
+  script injecté dans le build de « voler sous le radar » pour élever ses
+  privilèges).
+  Sources :
+  <https://github.com/pypa/gh-action-pypi-publish#trusted-publishing>,
+  <https://docs.pypi.org/trusted-publishers/security-model/>
+- `id-token: write` **ne donne aucun droit d'écriture** sur les ressources du
+  dépôt : cela autorise seulement le workflow à *demander* et *utiliser* un jeton
+  OIDC.
+  Source : <https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers>
+- Dès qu'un bloc `permissions:` est déclaré, **toutes les portées non listées
+  passent à `none`**. Le job de publication n'a besoin de rien d'autre que
+  `id-token: write` (ajouter `contents: read` seulement si le job checkout le
+  code ; `contents: write` seulement s'il crée aussi une *GitHub Release*).
+  Source : <https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/control-permissions-for-github_token>
+
+### 3.2 Environnement GitHub nommé `pypi`
+
+Référencer `environment: name: pypi` dans le job : GitHub **applique les règles
+de protection de l'environnement avant que le job démarre** et avant d'exposer
+les secrets d'environnement.
+Source : <https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments>
+
+Règles de protection à configurer sur l'environnement `pypi`
+(*Settings → Environments → pypi*) :
+
+| Règle (nom exact GitHub) | Recommandation |
+|---|---|
+| **Required reviewers** (jusqu'à 6 users/teams, option *Prevent self-review*) | Activer — porte d'approbation manuelle avant chaque publication |
+| **Wait timer** | Optionnel (ex. 0 ou quelques minutes) |
+| **Deployment branches and tags** | Passer sur *Selected branches and tags* et ajouter une règle **tag** `v*` → l'environnement ne peut être utilisé que depuis un tag de release (défense en profondeur, en plus du garde `if:` du §6) |
+| **Allow administrators to bypass configured protection rules** | À décider (désactiver pour un contrôle strict) |
+
+Source : <https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments>
+
+> Avec Trusted Publishing, l'environnement ne sert **pas** à héberger un secret :
+> il sert de point d'application des règles de protection (revue manuelle,
+> restriction aux tags). Ajouter un `url:` (ex.
+> `https://pypi.org/p/dh-healthdcat`) est purement cosmétique (lien dans l'UI
+> *Deployments*).
+
+### 3.3 Version de `pypa/gh-action-pypi-publish`
+
+- Référence recommandée par la doc officielle : **`pypa/gh-action-pypi-publish@release/v1`**
+  (tag mouvant maintenu par la PyPA ; l'ancienne branche `master` est *sunset*).
+  Source : <https://github.com/pypa/gh-action-pypi-publish#readme>
+- **Durcissement recommandé** : épingler un **SHA de commit complet** plutôt que
+  `release/v1` (ou un tag `vX.Y.Z` exact), et laisser Dependabot faire les bumps.
+  Ne **pas** utiliser les branches mouvantes type `unstable/v1`.
+  Source : <https://github.com/pypa/gh-action-pypi-publish#readme>
+- Action de type **composite** ; ne tourne **que sous Linux** (`runner.os == 'Linux'`).
+  Source : `action.yml` —
+  <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/action.yml>
+- **Ne pas** invoquer `pypi-publish` plus d'une fois dans le même job (non
+  supporté), et **ne pas** l'utiliser dans une matrice — Trusted Publishing en
+  *reusable workflow* est le seul cas explicitement **non supporté**.
+  Source : <https://github.com/pypa/gh-action-pypi-publish#readme>
+- Version publiée la plus récente au moment de la recherche : **v1.14.2**
+  (série v1.14.x, mi-2026). Les attestations PEP 740 sont **activées par défaut
+  depuis v1.11.0** (novembre 2024) — voir §5.
+  Sources :
+  <https://github.com/pypa/gh-action-pypi-publish/releases>,
+  <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0>
+
+### 3.4 Inputs de l'action (`with:`) et leurs défauts
+
+Aucun input n'est requis pour le chemin Trusted Publishing (laisser `user` et
+`password` **non renseignés** active le flux OIDC). Défauts effectifs relevés
+dans `action.yml` (`release/v1`) :
+
+| Input (kebab-case) | Défaut effectif | Rôle |
+|---|---|---|
+| `user` | `__token__` | ne pas surcharger en Trusted Publishing |
+| `password` | *(non défini)* | **laisser vide** → déclenche OIDC ; le renseigner désactive le mode *secretless* |
+| `repository-url` | `https://upload.pypi.org/legacy/` | mettre `https://test.pypi.org/legacy/` pour TestPyPI |
+| `packages-dir` | `dist` | dossier des distributions à uploader |
+| `attestations` | `true` | génère + upload les attestations PEP 740 (PyPI/TestPyPI + Trusted Publishing seulement) ; `false` pour désactiver |
+| `verify-metadata` | `true` | `twine check` avant upload |
+| `skip-existing` | `false` | ne pas échouer si le fichier existe déjà (à éviter en prod) |
+| `verbose` | `true` | sortie détaillée |
+| `print-hash` | `true` | affiche SHA256/MD5/BLAKE2-256 des fichiers uploadés |
+
+Source : <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/action.yml>
+et README (sections *Options* / *Disabling metadata verification* / *Tolerating
+… duplicates* / *For Debugging*) —
+<https://github.com/pypa/gh-action-pypi-publish#readme>
+
+---
+
+## 4. Construire `sdist` + `wheel` avec `uv build` et uploader `dist/`
+
+- `uv build` construit le projet du répertoire courant et place les artefacts
+  dans un sous-dossier **`dist/`**.
+  Source : <https://docs.astral.sh/uv/guides/package/>
+- **Par défaut, `uv build` construit d'abord une *source distribution* (sdist),
+  puis une *wheel* à partir de cette sdist.** `uv build --sdist` ou
+  `uv build --wheel` limitent à un seul format ; `uv build --sdist --wheel`
+  force les deux depuis les sources.
+  Source : <https://docs.astral.sh/uv/concepts/projects/build/>
+- `uv build --no-sources` est recommandé avant publication pour vérifier que le
+  paquet se construit sans `tool.uv.sources` (comme le ferait un consommateur
+  via `pypa/build`).
+  Source : <https://docs.astral.sh/uv/guides/package/>
+- `--out-dir` (alias `-o`) change le dossier de sortie (défaut `dist/`).
+  Source : <https://docs.astral.sh/uv/concepts/projects/build/>
+- Ici le backend de build déclaré dans `pyproject.toml` est **hatchling** ;
+  `uv build` respecte le backend PEP 517 déclaré, donc rien de spécial à faire.
+- Côté publication : après `uv build`, uploader le **dossier `dist/` entier**
+  (`packages-dir` par défaut = `dist`). `gh-action-pypi-publish` upload tous les
+  fichiers du dossier (sdist `*.tar.gz` + wheel `*.whl`).
+  Source : <https://github.com/pypa/gh-action-pypi-publish#readme>
+
+> **Note sur `uv publish`.** `uv` sait aussi publier lui-même
+> (`uv publish`, sans credentials en Trusted Publishing). **Mais `uv publish`
+> n'émet pas d'attestations PEP 740** : l'exemple officiel Astral ajoute pour
+> cela une étape `astral-sh/attest-action`. Comme les attestations *hors*
+> `attest-build-provenance` sont un objectif de ce ticket et que
+> `gh-action-pypi-publish` les fournit **sans étape supplémentaire**, on
+> privilégie `uv build` (build) **+** `pypa/gh-action-pypi-publish` (publish).
+> Source : <https://docs.astral.sh/uv/guides/integration/github/> (section
+> *Publishing to PyPI*).
+
+---
+
+## 5. Attestations PEP 740 / Sigstore
+
+### État par défaut
+
+- **`pypa/gh-action-pypi-publish` génère et upload des attestations numériques
+  signées pour tous les fichiers de distribution, activé PAR DÉFAUT pour tout
+  projet en Trusted Publishing.** Introduit en opt-in en **v1.10.0**, basculé
+  **on-by-default en v1.11.0** (novembre 2024).
+  Sources :
+  <https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations>,
+  <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0>,
+  <https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/>
+- PyPI a finalisé le support de **PEP 740** le **14 novembre 2024** ; les
+  attestations sont **vérifiées à l'upload** (seules des attestations valides
+  entrent dans l'index) et affichées sur la page du projet.
+  Source : <https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/>
+- Les objets d'attestation sont créés avec **Sigstore** pour chaque
+  distribution, signés avec **l'identité fournie par le jeton OIDC GitHub du
+  workflow courant** : l'authentification Trusted Publishing **et** les
+  attestations sont donc liées à la **même identité**.
+  Source : <https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations>
+- Contraintes : le support des attestations est **limité aux flux Trusted
+  Publishing sur PyPI / TestPyPI** ; il **requiert** l'authentification par
+  trusted publisher.
+  Source : <https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations>
+- PyPI accepte au plus **2 attestations par fichier**, avec deux *predicate
+  types* : *SLSA Provenance* et *PyPI Publish*.
+  Source : <https://docs.pypi.org/attestations/>
+
+### Comment désactiver / régler
+
+```yaml
+- uses: pypa/gh-action-pypi-publish@release/v1
+  with:
+    attestations: false   # défaut: true
+```
+
+Source : <https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations>
+
+### PGP
+
+Le support des **signatures PGP a été déprécié puis retiré** par PyPI (beaucoup
+de signatures n'étaient pas vérifiables). Les attestations PEP 740 basées sur
+l'identité OIDC les **remplacent**. Il n'y a **plus** d'option PGP dans
+`gh-action-pypi-publish`.
+Source : <https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/>
+
+### Frontière avec `actions/attest-build-provenance` (HORS périmètre)
+
+| Aspect | `gh-action-pypi-publish` (attestations PEP 740) | `actions/attest-build-provenance` (HORS périmètre) |
+|---|---|---|
+| Standard | **PEP 740** (format d'attestation PyPI) | **SLSA Provenance v1** (in-toto) |
+| Où c'est stocké / vérifié | Uploadé **sur PyPI** à côté du fichier, vérifié par PyPI à l'upload, visible sur la page projet | Magasin d'attestations **GitHub**, vérifié via `gh attestation verify` / API GitHub |
+| Déclenchement | Automatique dans le step de publish (`attestations: true`) | Step séparé explicite dans le workflow |
+| Identité | Jeton OIDC GitHub du workflow (Sigstore) | Jeton OIDC GitHub du workflow (Sigstore) |
+| Permissions | `id-token: write` | `id-token: write` **+** `attestations: write` |
+
+Les deux sont complémentaires mais **cet effort ne met en place que le premier**.
+Ne pas ajouter `actions/attest-build-provenance` ni `astral-sh/attest-action`
+dans le cadre du ticket #23.
+Sources :
+<https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations>,
+<https://docs.pypi.org/attestations/>
+
+---
+
+## 6. Conditionner la publication aux tags/releases (jamais sur `main`)
+
+Trois verrous **cumulatifs** (défense en profondeur) :
+
+1. **Trigger du workflow** — ne déclencher que sur tags :
+
+   ```yaml
+   on:
+     push:
+       tags:
+         - "v*"
+   ```
+
+2. **Garde `if:` sur le job de publication** — recommandé par le README de
+   l'action :
+
+   ```yaml
+   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+   ```
+
+   Source : <https://github.com/pypa/gh-action-pypi-publish#readme>
+
+3. **Environnement GitHub `pypi`** — règle *Deployment branches and tags* limitée
+   à un pattern de tag `v*`, + *Required reviewers*. GitHub refuse d'exécuter le
+   job (donc l'accès OIDC élevé) si la ref ne matche pas.
+   Source : <https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments>
+
+Côté gouvernance dépôt : restreindre la **création/modification des tags `v*`**
+aux mainteneurs (rulesets GitHub) — recommandation du modèle de sécurité PyPI
+pour les workflows *tag-based*.
+Source : <https://docs.pypi.org/trusted-publishers/security-model/>
+
+Recommandations complémentaires du modèle de sécurité PyPI :
+
+- Le job de publication doit idéalement n'avoir que **2 steps** : récupérer les
+  dists produites par un **job de build séparé**, puis publier avec
+  `pypa/gh-action-pypi-publish@release/v1`.
+- **Séparer build et publish** en deux jobs, partager `dist/` via
+  `actions/upload-artifact` → `actions/download-artifact`, afin qu'un script
+  malveillant injecté au build ne puisse pas élever ses privilèges.
+- Ne **jamais** utiliser `pull_request_target` pour ce type de workflow.
+Sources :
+<https://docs.pypi.org/trusted-publishers/security-model/>,
+<https://github.com/pypa/gh-action-pypi-publish#trusted-publishing>
+
+---
+
+## 7. Workflow de référence (à créer : `.github/workflows/release.yml`)
+
+> Fourni à titre de référence pour l'implémentation ultérieure ; ce ticket est
+> une recherche, il ne crée pas le workflow. Nom de fichier `release.yml` à
+> **enregistrer tel quel** côté PyPI (§2).
+
+```yaml
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}   # rien par défaut ; chaque job élève ce dont il a besoin
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha>          # v4.x
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@<sha>        # vX.Y.Z
+      - name: Build
+        run: uv build --no-sources            # sdist puis wheel -> dist/
+      - name: Check metadata
+        run: uvx twine check dist/*
+      - uses: actions/upload-artifact@<sha>   # v4.x
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing)
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dh-healthdcat
+    permissions:
+      id-token: write          # OBLIGATOIRE pour Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@<sha> # v4.x
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@<sha>   # release/v1 -> épingler un SHA
+        # aucun input requis :
+        #   - user/password laissés vides -> flux OIDC
+        #   - packages-dir défaut "dist"
+        #   - attestations défaut true  -> attestations PEP 740 émises
+```
+
+Sources de la structure :
+<https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/>,
+<https://docs.astral.sh/uv/guides/integration/github/>,
+<https://github.com/pypa/gh-action-pypi-publish#trusted-publishing>
+
+---
+
+## Recommandation
+
+1. **Utiliser Trusted Publishing (OIDC), pas de token API.** Enregistrer un
+   *pending publisher* côté PyPI pour `dh-healthdcat`
+   (`davidouagne` / `datahub-healthdcat-ap-exporter` / `release.yml` / env
+   `pypi`) ; le projet sera créé automatiquement à la première publication.
+2. **Build avec `uv build --no-sources`** (sdist puis wheel dans `dist/`),
+   **publish avec `pypa/gh-action-pypi-publish`** épinglé à un **SHA de commit**
+   (piste `release/v1`, bumps Dependabot). On retient `gh-action-pypi-publish`
+   plutôt que `uv publish` **parce qu'il émet les attestations PEP 740 sans
+   étape supplémentaire**.
+3. **Attestations PEP 740 : ne rien faire.** Elles sont **on-by-default** depuis
+   `gh-action-pypi-publish` v1.11.0 et signées via l'identité OIDC du workflow.
+   Laisser `attestations: true`. **Ne pas** ajouter
+   `actions/attest-build-provenance` ni `astral-sh/attest-action` (hors
+   périmètre).
+4. **Trois verrous cumulés contre une publication sur `main`** : trigger
+   `on: push: tags: ["v*"]`, garde
+   `if: startsWith(github.ref, 'refs/tags')` sur le job publish, environnement
+   `pypi` avec *Required reviewers* + *Deployment branches and tags* limité à
+   `v*`. **Séparer build et publish** en deux jobs ; `id-token: write`
+   uniquement sur le job publish ; `permissions: {}` au niveau workflow.
+5. **Durcissement** : ruleset GitHub restreignant la création des tags `v*` aux
+   mainteneurs ; `persist-credentials: false` au checkout ; épingler toutes les
+   actions par SHA.
+
+---
+
+## Hand-off checklist (côté PyPI)
+
+Pré-requis : compte PyPI avec 2FA, membre/owner (à venir) du projet
+`dh-healthdcat`.
+
+- [ ] **Cas projet inexistant (actuel)** — se connecter à PyPI →
+      *Account settings* → *Publishing* → *Add a new pending publisher* →
+      **GitHub Actions**.
+- [ ] Renseigner :
+  - [ ] *PyPI Project Name* : `dh-healthdcat`
+  - [ ] *Owner* : `davidouagne`
+  - [ ] *Repository name* : `datahub-healthdcat-ap-exporter`
+  - [ ] *Workflow name* : `release.yml`  (basename exact, sans chemin)
+  - [ ] *Environment name* : `pypi`
+- [ ] *Add*. Vérifier que le pending publisher apparaît dans la liste.
+- [ ] (Rappel : le nom `dh-healthdcat` n'est **pas** réservé tant qu'aucune
+      publication n'a eu lieu — publier rapidement après création.)
+- [ ] **Après première publication** : vérifier dans *Manage project →
+      Publishing* que le trusted publisher est bien listé (plus « pending »).
+- [ ] **Optionnel — TestPyPI** : répéter sur <https://test.pypi.org> avec un
+      environnement GitHub `testpypi` distinct et un job publish dédié
+      (`repository-url: https://test.pypi.org/legacy/`).
+- [ ] Si le dépôt est un jour **renommé / transféré / le workflow renommé** :
+      mettre à jour le publisher côté PyPI (sinon 403 à l'upload).
+
+Côté GitHub (pour mémoire, non « PyPI side » mais bloquant) :
+
+- [ ] Créer l'environnement `pypi` (*Settings → Environments*) avec *Required
+      reviewers* et *Deployment branches and tags* = *Selected* + règle tag `v*`.
+- [ ] Ruleset restreignant la création des tags `v*` aux mainteneurs.
+- [ ] Créer `.github/workflows/release.yml` (cf. §7).
+
+---
+
+## Sources
+
+Toutes consultées le 2026-08-28.
+
+- PyPI — Trusted Publishers, overview : <https://docs.pypi.org/trusted-publishers/>
+- PyPI — Adding a Trusted Publisher to an existing project : <https://docs.pypi.org/trusted-publishers/adding-a-publisher/>
+- PyPI — Creating a PyPI project with a Trusted Publisher (pending publisher) : <https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/>
+- PyPI — Publishing with a Trusted Publisher (workflow recommandé) : <https://docs.pypi.org/trusted-publishers/using-a-publisher/>
+- PyPI — Security model and considerations : <https://docs.pypi.org/trusted-publishers/security-model/>
+- PyPI — Digital attestations (PEP 740) : <https://docs.pypi.org/attestations/>
+- PyPI blog — « PyPI now supports digital attestations », 2024-11-14 : <https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/>
+- PEP 740 — Index support for digital attestations : <https://peps.python.org/pep-0740/>
+- `pypa/gh-action-pypi-publish` — README : <https://github.com/pypa/gh-action-pypi-publish#readme>
+- `pypa/gh-action-pypi-publish` — `action.yml` (`release/v1`) : <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/action.yml>
+- `pypa/gh-action-pypi-publish` — Releases : <https://github.com/pypa/gh-action-pypi-publish/releases>
+- `pypa/gh-action-pypi-publish` — Release v1.11.0 (attestations on-by-default) : <https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0>
+- GitHub Docs — OIDC in cloud providers / `id-token: write` : <https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers>
+- GitHub Docs — Control permissions for `GITHUB_TOKEN` : <https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/control-permissions-for-github_token>
+- GitHub Docs — Managing environments for deployment (protection rules) : <https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments>
+- Python Packaging User Guide — Publishing package distribution releases using GitHub Actions : <https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/>
+- uv — Building and publishing a package : <https://docs.astral.sh/uv/guides/package/>
+- uv — Building distributions (`uv build`) : <https://docs.astral.sh/uv/concepts/projects/build/>
+- uv — GitHub Actions integration (Publishing to PyPI) : <https://docs.astral.sh/uv/guides/integration/github/>

--- a/docs/research/release-please-python.md
+++ b/docs/research/release-please-python.md
@@ -1,0 +1,430 @@
+# release-please pour un paquet Python + publication PyPI (Trusted Publishing)
+
+Recherche préalable aux tickets « Configuration release-please » (#25) et
+« Topologie du workflow de release ». Objet : fixer, **depuis les sources primaires**,
+le patron 2026 pour automatiser les releases de `dh-healthdcat` (paquet unique,
+`src/dh_healthdcat/`, build-backend `hatchling`, `[project].version` statique) et
+chaîner une publication PyPI sans jeton long-lived.
+
+Vérifié le 2026-08-28 contre les sources primaires listées en fin de document
+(release-please `17.11.2`, `googleapis/release-please-action@v4`).
+
+## 1. Action et version courantes
+
+- **`googleapis/release-please-action@v4`**. Le dépôt de l'action est
+  `googleapis/release-please-action` (l'ancien `google-github-actions/release-please-action`
+  n'est plus le canonique). Runtime `node24`.
+  Source : <https://github.com/googleapis/release-please-action/blob/main/action.yml>,
+  <https://github.com/googleapis/release-please-action/blob/main/README.md>.
+- CLI/bibliothèque sous-jacente : `googleapis/release-please`, version `17.11.2`
+  au 2026-08-28 (`package.json`).
+  Source : <https://github.com/googleapis/release-please/blob/main/package.json>.
+- **v4 est « manifest-first »** : si `release-type` n'est **pas** renseigné, l'action
+  lit une configuration manifeste (`release-please-config.json` +
+  `.release-please-manifest.json`). Toute configuration avancée passe désormais
+  obligatoirement par ces fichiers ; les anciennes entrées d'action (`changelog-types`,
+  `extra-files`, `bump-minor-pre-major`, …) ont été retirées au profit des clés du
+  fichier de config.
+  Source : README §« Advanced Release Configuration » et §« Upgrading from v3 to v4 »
+  <https://github.com/googleapis/release-please-action/blob/main/README.md>.
+
+## 2. `release-type: python` — ce qu'il bumpe exactement
+
+Stratégie `Python` : `src/strategies/python.ts`. À chaque release, elle produit les
+`Update` suivants (tous en `createIfMissing: false`, sauf le CHANGELOG) :
+Source : <https://github.com/googleapis/release-please/blob/main/src/strategies/python.ts>.
+
+| Fichier | Comportement |
+|---|---|
+| `CHANGELOG.md` | créé si absent |
+| `setup.cfg` | mis à jour **si présent** |
+| `setup.py` | mis à jour **si présent** |
+| `pyproject.toml` | mis à jour **si présent et versionné** (voir ci-dessous) |
+| `<name>/__init__.py`, `src/<name>/__init__.py`, idem avec `-`→`_` | ligne `__version__` remplacée **si le fichier et la ligne existent** |
+| tout `version.py` trouvé dans le repo (recherche par nom de fichier) | ligne `__version__` remplacée |
+| `changelog.json` | mis à jour **si présent** |
+
+### `pyproject.toml` : support natif de `[project].version` (PEP 621)
+
+`src/updaters/python/pyproject-toml.ts` lit `parsed.project || parsed.tool?.poetry`
+et réécrit la clé `version` sous `[project]` (PEP 621) **ou**, à défaut, sous
+`[tool.poetry]`. Donc :
+
+- `[project].version = "x.y.z"` **statique** → supporté **nativement**, aucun
+  `extra-files` ni plugin nécessaire. C'est le cas de `dh-healthdcat` aujourd'hui.
+- Si `version` est dans `[project].dynamic` (version calculée, p. ex. `hatch-vcs`/
+  `setuptools-scm`), l'updater **loggue un warning et ne touche pas au fichier**
+  (« dynamic version found in 'pyproject.toml'. Skipping update. »). Dans ce cas la
+  source de vérité reste le tag Git ; release-please ne pilote plus la version dans
+  `pyproject.toml`.
+- `pyproject.toml` sans clé `version` du tout et sans `dynamic` → l'updater lève
+  `Error('invalid file')`.
+
+Source : <https://github.com/googleapis/release-please/blob/main/src/updaters/python/pyproject-toml.ts>.
+
+### `__version__` dans `src/dh_healthdcat/__init__.py`
+
+Updater `PythonFileWithVersion` : simple remplacement par regex
+
+```
+/(__version__ ?= ?["'])[0-9]+\.[0-9]+\.[0-9]+(?:-\w+)?(["'])/
+```
+
+Source : <https://github.com/googleapis/release-please/blob/main/src/updaters/python/python-file-with-version.ts>.
+
+Conséquences pour ce repo :
+
+- Le nom de paquet `[project].name = "dh-healthdcat"` : la stratégie teste
+  `dh-healthdcat/…` **et** `dh_healthdcat/…` (substitution `-`→`_`), préfixés ou non
+  par `src/`. Donc `src/dh_healthdcat/__init__.py` **est bien dans la liste des
+  cibles** — pas de config supplémentaire à prévoir pour l'y inclure.
+- **Mais** `createIfMissing: false` + regex exigeant une ligne déjà présente : le
+  `src/dh_healthdcat/__init__.py` **actuellement vide** ne sera pas modifié tant
+  qu'on n'y ajoute pas manuellement une première ligne `__version__ = "0.1.0"`
+  (format semver strict, guillemets simples ou doubles). Sans cette ligne, la mise à
+  jour est silencieusement ignorée — pas d'erreur.
+- Il n'y a **pas** de mécanisme « ajouter le `__version__` s'il n'existe pas ».
+
+### Alternative générique : `extra-files`
+
+Pour tout fichier non couvert (ou pour forcer un chemin), la config manifeste accepte
+`extra-files` avec des updaters typés. Pour du TOML :
+
+```json
+{
+  "extra-files": [
+    { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" }
+  ]
+}
+```
+
+Types disponibles : `json` / `yaml` / `toml` (via `jsonpath`), `xml` (via `xpath`),
+et le « Generic updater » (annotations `x-release-please-version` /
+`x-release-please-start-version` … `x-release-please-end` dans le fichier).
+Pour `dh-healthdcat`, `extra-files` **n'est pas nécessaire** : `[project].version`
+statique est déjà géré nativement.
+Source : <https://github.com/googleapis/release-please/blob/main/docs/customizing.md> (§ Updating arbitrary files).
+
+### Version initiale
+
+`initialReleaseVersion()` de la stratégie Python = `0.1.0` (surchargée par
+`initial-version` / `release-as` au besoin).
+Source : `src/strategies/python.ts`.
+
+## 3. Mode `manifest` vs config simple (repo mono-paquet)
+
+- **Config « simple » (`release-type: python` seul, sans fichiers)** : possible,
+  « the most straight-forward configuration option, but allows for **no further
+  customization** » (README). Aucun `changelog-sections`, aucun `extra-files`,
+  aucun réglage fin.
+- **Mode manifeste** : deux fichiers versionnés — `release-please-config.json`
+  (config) et `.release-please-manifest.json` (versions courantes, `{}` au
+  bootstrap). Le paquet racine se déclare avec le chemin spécial `"."`.
+  « originally designed for repositories that contain multiple releasable
+  artifacts [...] also supports single artifact workflows just as easily. »
+  Source : <https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md>.
+
+Exemple minimal pour `dh-healthdcat` (`release-please-config.json`) :
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "package-name": "dh-healthdcat"
+    }
+  }
+}
+```
+
+et `.release-please-manifest.json` :
+
+```json
+{ ".": "0.1.0" }
+```
+
+**Recommandation : mode manifeste**, même pour un paquet unique. Motifs : c'est le
+mode par défaut de l'action v4, le seul qui donne accès à `changelog-sections` /
+`extra-files` / `bootstrap-sha` / `initial-version`, il fige la config en revue de
+code, et il évite une réécriture le jour où un 2ᵉ artefact apparaît. Aucune source
+primaire ne déclare le mode non-manifeste « déprécié », mais toute la doc avancée et
+le README v4 sont écrits pour le manifeste.
+
+## 4. Sections CHANGELOG : mapping des types Conventional Commits
+
+**Important** : la stratégie Python définit **son propre défaut**
+`CHANGELOG_SECTIONS`, différent du défaut global de release-please
+(`src/strategies/python.ts`) :
+
+| type | section | visible ? |
+|---|---|---|
+| `feat` | Features | oui |
+| `fix` | Bug Fixes | oui |
+| `perf` | Performance Improvements | oui |
+| `deps` | Dependencies | oui |
+| `revert` | Reverts | oui |
+| `docs` | Documentation | **oui** (visible pour la stratégie Python) |
+| `style` | Styles | `hidden: true` |
+| `chore` | Miscellaneous Chores | `hidden: true` |
+| `refactor` | Code Refactoring | `hidden: true` |
+| `test` | Tests | `hidden: true` |
+| `build` | Build System | `hidden: true` |
+| `ci` | Continuous Integration | `hidden: true` |
+
+Pour mémoire, le **défaut global** (preset `conventional-changelog-conventionalcommits`
+`^6.0.0`, épinglé par release-please) masque en plus `docs` et ne connaît pas `deps` :
+`feat`/`feature`→Features, `fix`→Bug Fixes, `perf`→Performance Improvements,
+`revert`→Reverts, puis `docs`/`style`/`chore`/`refactor`/`test`/`build`/`ci` tous
+`hidden: true`.
+Sources : <https://github.com/googleapis/release-please/blob/main/src/strategies/python.ts>,
+<https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js>,
+<https://github.com/googleapis/release-please/blob/main/src/changelog-notes/default.ts>.
+
+### Réponses à la question posée (`feat`, `fix`, `test`, `docs`, `chore`)
+
+Avec `release-type: python` et **sans** override :
+
+- `feat` → section **Features**, visible ; bump **minor**.
+- `fix` → section **Bug Fixes**, visible ; bump **patch**.
+- `docs` → section **Documentation**, **visible** (spécificité Python) ; **pas de bump**.
+- `test` → section **Tests**, **masquée** ; pas de bump.
+- `chore` → section **Miscellaneous Chores**, **masquée** ; pas de bump.
+- `feat!` / `fix!` / `<type>!` ou pied de commit `BREAKING CHANGE:` → bump **major**
+  (pré-1.0 : `bump-minor-pre-major` / `bump-patch-for-minor-pre-major` modulent).
+  Source : README §« How should I write my commits? »
+  <https://github.com/googleapis/release-please-action/blob/main/README.md>.
+
+### Override via `changelog-sections`
+
+Clé `changelog-sections` dans `release-please-config.json` (racine ou par-paquet).
+Le tableau fourni **remplace intégralement** la liste des types (il n'est pas
+fusionné avec le défaut : dans `src/changelog-notes/default.ts`, `config.types =
+options.changelogSections`). Il faut donc **re-lister tous les types voulus**, y
+compris `feat`/`fix`. Exemple pour rendre `test` visible et garder le reste du défaut
+Python :
+
+```json
+{
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "package-name": "dh-healthdcat",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "test", "section": "Tests" },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+      ]
+    }
+  }
+}
+```
+
+Note : le mapping type→bump (`feat`=minor, `fix`=patch, `!`=major) est **indépendant**
+de `changelog-sections` ; renommer/masquer une section ne change pas le calcul de
+version. (Un `chore:` ne bumpe pas — cf. `googleapis/release-please#2638`.)
+Source : <https://github.com/googleapis/release-please/blob/main/docs/customizing.md>.
+
+## 5. Chaînage : release-please → build/publish PyPI
+
+### Le piège central (`GITHUB_TOKEN`)
+
+À la fusion de la Release PR, release-please crée le **tag** et la **GitHub Release**
+via l'API, authentifié avec le token de l'action. Si ce token est le `GITHUB_TOKEN`
+par défaut :
+
+> « all resources created by `release-please` (release tag or release pull request)
+> **will not trigger future GitHub actions workflows**, and workflows normally
+> triggered by `release.created` events **will also not run**. »
+> — README release-please-action, §« Other Actions on Release Please PRs ».
+
+C'est la règle GitHub générale :
+
+> « When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered
+> by the `GITHUB_TOKEN` will not create a new workflow run [...] with the following
+> exceptions » — seuls `workflow_dispatch` et `repository_dispatch` (et
+> `pull_request` `opened`/`synchronize`/`reopened`, mais en état « approval
+> required ») échappent à la règle.
+> Source : <https://docs.github.com/en/actions/concepts/security/github_token>
+> (« GITHUB_TOKEN »), introduit le 2022-09-08
+> <https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/>.
+
+Donc **`on: release: [published]` ET `on: push: tags:` sont tous deux inertes** si
+release-please tourne avec le `GITHUB_TOKEN`. Choisir entre ces deux triggers ne
+règle rien ; il faut lever le blocage à la source.
+
+### Contournements (par ordre de préférence pour un repo mono-paquet)
+
+1. **Publier dans le même workflow, étape gardée par `release_created`** (patron
+   recommandé par le README de l'action, exemple `npm publish` transposé) :
+
+   ```yaml
+   name: release-please
+   on:
+     push:
+       branches: [main]
+   permissions:
+     contents: write
+     issues: write
+     pull-requests: write
+   jobs:
+     release-please:
+       runs-on: ubuntu-latest
+       outputs:
+         release_created: ${{ steps.release.outputs.release_created }}
+         tag_name: ${{ steps.release.outputs.tag_name }}
+       steps:
+         - uses: googleapis/release-please-action@v4
+           id: release
+           with:
+             config-file: release-please-config.json
+             manifest-file: .release-please-manifest.json
+     publish:
+       needs: release-please
+       if: ${{ needs.release-please.outputs.release_created == 'true' }}
+       runs-on: ubuntu-latest
+       environment: pypi
+       permissions:
+         id-token: write            # OIDC / PyPI Trusted Publishing
+       steps:
+         - uses: actions/checkout@v4
+           with:
+             ref: ${{ needs.release-please.outputs.tag_name }}
+         - uses: actions/setup-python@v5
+           with:
+             python-version: "3.x"
+         - run: python -m pip install -U build
+         - run: python -m build
+         - uses: pypa/gh-action-pypi-publish@release/v1
+   ```
+
+   Sorties utiles : `release_created` (composant racine), `releases_created`,
+   `tag_name`, `version`, `sha`, `paths_released`. En mode multi-paquets les sorties
+   sont préfixées `"<path>--release_created"`, etc.
+   Source : README §Outputs
+   <https://github.com/googleapis/release-please-action/blob/main/README.md>.
+
+   Avantages : pas de second token, pas de piège de trigger, checkout garanti sur le
+   bon tag via `tag_name`. Inconvénient : le job publish vit dans le workflow
+   « release-please » plutôt que dans un workflow dédié `on: release`.
+
+2. **Faire tourner release-please avec un token qui déclenche les workflows**
+   (Personal Access Token à portée fine, ou token d'installation d'une GitHub App —
+   p. ex. `actions/create-github-app-token`). Le tag/Release étant alors créés sous
+   une autre identité, un workflow séparé `on: release: types: [published]` ou
+   `on: push: tags: ['v*']` se déclenche normalement. C'est aussi ce qu'il faut pour
+   que la **CI s'exécute sur la Release PR elle-même**.
+   Source : README §« GitHub Credentials » / §« Other Actions on Release Please PRs ».
+
+3. **`workflow_dispatch` / `repository_dispatch` explicite** depuis le job
+   release-please (ces deux events déclenchent même via `GITHUB_TOKEN`). Plus de
+   pièces mobiles ; utile si le publish doit rester un workflow autonome sans PAT.
+
+### Côté PyPI : Trusted Publishing (OIDC), pas de token long-lived
+
+- Trusted Publishing échange un jeton OIDC éphémère (≤ 15 min) contre un token
+  d'upload ; « trusted publishing is now encouraged over API tokens as a best
+  practice ». GitHub Actions est un fournisseur OIDC supporté.
+  Sources : <https://docs.pypi.org/trusted-publishers/>,
+  <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/README.md>.
+- Le job qui publie doit avoir **`permissions: id-token: write`** (mandatory),
+  posé **au niveau du job** et non du workflow (« only set the `id-token: write`
+  permission in the job that does the publishing »).
+  Source : <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/README.md>.
+- Utiliser **`pypa/gh-action-pypi-publish@release/v1`** (la branche `master` est
+  sunset ; épingler `release/v1` ou un SHA). Ne passer **ni `user` ni `password`**
+  pour rester en flux OIDC. L'action ne construit pas les dists : `python -m build`
+  en amont, artefacts dans `dist/`.
+  Source : idem, §« Trusted Publishing » et §« Non-goals ».
+- **GitHub Environment** (`environment: pypi`) « optional, but strongly encouraged » —
+  permet règles de protection + scoping du Trusted Publisher côté PyPI.
+  Source : <https://docs.pypi.org/trusted-publishers/using-a-publisher/>.
+- Exemple canonique PyPI : trigger `on: release: types: [published]` (valable
+  **uniquement** si la Release est créée par une identité ≠ `GITHUB_TOKEN`, cf.
+  contournement 2). Sinon, préférer le contournement 1.
+  Source : <https://docs.pypi.org/trusted-publishers/using-a-publisher/>.
+
+## 6. Permissions requises
+
+### Job release-please (`googleapis/release-please-action@v4`)
+
+```yaml
+permissions:
+  contents: write         # créer commits/branche de la Release PR, tag, GitHub Release
+  pull-requests: write    # ouvrir/mettre à jour la Release PR
+  issues: write           # labels (déclaré requis par le README ; sinon skip-labeling: true)
+```
+
+Plus, côté repo : Settings → Actions → General → « Allow GitHub Actions to create and
+approve pull requests ».
+Source : README §« Workflow Permissions »
+<https://github.com/googleapis/release-please-action/blob/main/README.md>.
+
+### Job publish PyPI
+
+```yaml
+permissions:
+  id-token: write         # obligatoire pour Trusted Publishing (OIDC)
+  contents: read          # checkout du tag
+```
+
+Source : <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/README.md>,
+<https://docs.pypi.org/trusted-publishers/using-a-publisher/>.
+
+## Recommendation
+
+1. **Mode manifeste** (`release-please-config.json` + `.release-please-manifest.json`),
+   paquet racine `"."`, `release-type: python`, `package-name: "dh-healthdcat"`.
+   C'est le défaut de l'action v4 et le seul mode donnant accès à `changelog-sections`.
+2. **Garder `[project].version` statique dans `pyproject.toml`** : release-please le
+   bumpe nativement (PEP 621), rien à configurer. Ne pas passer la version en
+   `dynamic` (sinon release-please cesse de la piloter). `setup.py`/`setup.cfg`
+   absents → non concernés.
+3. **`__version__`** : si on veut qu'il soit synchronisé, ajouter **une fois**
+   `__version__ = "0.1.0"` dans `src/dh_healthdcat/__init__.py` (aujourd'hui vide) ;
+   ce chemin est déjà dans les cibles de la stratégie Python (nom `dh-healthdcat` →
+   `dh_healthdcat`). Sinon, laisser le fichier vide et exposer la version via
+   `importlib.metadata.version("dh-healthdcat")` — dans ce cas ne rien ajouter.
+4. **CHANGELOG** : le défaut de la stratégie Python suffit (`feat`/`fix`/`perf`/
+   `deps`/`revert`/`docs` visibles ; `test`/`chore`/`refactor`/`style`/`build`/`ci`
+   masqués). N'ajouter `changelog-sections` que si l'on veut dévoiler `test`/`chore` —
+   et alors **re-lister tous les types** (le tableau remplace le défaut).
+5. **Chaînage** : un seul workflow `on: push: branches: [main]`, job `release-please`
+   puis job `publish` avec `needs:` + `if: needs.release-please.outputs.release_created
+   == 'true'`, checkout sur `outputs.tag_name`. Éviter de dépendre d'un trigger
+   `on: release`/`on: push: tags` tant que release-please tourne sous `GITHUB_TOKEN`
+   (ces événements ne se déclenchent pas). Si un workflow `on: release` dédié est
+   souhaité, faire tourner release-please avec un token de GitHub App / PAT.
+6. **PyPI** : Trusted Publishing (OIDC), `pypa/gh-action-pypi-publish@release/v1`
+   sans `user`/`password`, `permissions: id-token: write` au niveau du job publish,
+   `environment: pypi`, `python -m build` en amont. Configurer le Trusted Publisher
+   côté PyPI (repo + nom de workflow + environnement).
+7. **Permissions** action : `contents: write`, `pull-requests: write`, `issues: write`
+   + activer « Allow GitHub Actions to create and approve pull requests ».
+
+## Sources
+
+- release-please-action — README : <https://github.com/googleapis/release-please-action/blob/main/README.md>
+- release-please-action — `action.yml` : <https://github.com/googleapis/release-please-action/blob/main/action.yml>
+- release-please — `package.json` (v17.11.2) : <https://github.com/googleapis/release-please/blob/main/package.json>
+- release-please — stratégie Python : <https://github.com/googleapis/release-please/blob/main/src/strategies/python.ts>
+- release-please — updater `pyproject.toml` : <https://github.com/googleapis/release-please/blob/main/src/updaters/python/pyproject-toml.ts>
+- release-please — updater `__version__` : <https://github.com/googleapis/release-please/blob/main/src/updaters/python/python-file-with-version.ts>
+- release-please — `changelog-notes/default.ts` (types = changelogSections) : <https://github.com/googleapis/release-please/blob/main/src/changelog-notes/default.ts>
+- release-please — doc « Customizing » (`extra-files`, `changelog-sections`) : <https://github.com/googleapis/release-please/blob/main/docs/customizing.md>
+- release-please — doc « Manifest releaser » : <https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md>
+- conventional-changelog-conventionalcommits — `constants.js` (défaut des types) : <https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/constants.js>
+- GitHub Docs — « GITHUB_TOKEN » (events non déclencheurs + exceptions) : <https://docs.github.com/en/actions/concepts/security/github_token>
+- GitHub Changelog — GITHUB_TOKEN + workflow_dispatch/repository_dispatch (2022-09-08) : <https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/>
+- PyPI Docs — Trusted Publishers (index) : <https://docs.pypi.org/trusted-publishers/>
+- PyPI Docs — « Using a publisher » (workflow OIDC, `id-token: write`, `on: release: published`, environment) : <https://docs.pypi.org/trusted-publishers/using-a-publisher/>
+- pypa/gh-action-pypi-publish — README (`release/v1`, Trusted Publishing, `id-token: write` au niveau du job, non-goals) : <https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/README.md>


### PR DESCRIPTION
Item « Documentation » de #29 : *« Merger les branches `research/*` (ou les archiver) — les notes de recherche valent d'être conservées. »*

Reprend par `cherry-pick -s` les 3 commits des branches `research/*` (sources primaires ayant servi aux résolutions #21 / #22 / #23, donc à ADR-0003) :

| Fichier | ~lignes | Branche d'origine |
|---|---|---|
| `docs/research/dependabot-uv.md` | 241 | `research/dependabot-uv` (#21) |
| `docs/research/release-please-python.md` | 430 | `research/release-please-python` (#22) |
| `docs/research/pypi-trusted-publishing.md` | 480 | `research/pypi-trusted-publishing` (#23) |

`cherry-pick -s` : contenu identique, messages CC inchangés, `Signed-off-by` ajouté (les commits d'origine n'en avaient pas → `dco` les aurait refusés).

Après merge, les 3 branches `research/*` peuvent être supprimées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)