### PR TITLE
docs: JSON reproductible des rulesets main et v*

### DIFF
--- a/docs/rulesets/main.json
+++ b/docs/rulesets/main.json
@@ -1,0 +1,44 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
+  },
+  "bypass_actors": [
+    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" }
+  ],
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "typecheck" },
+          { "context": "test (3.10)" },
+          { "context": "test (3.11)" },
+          { "context": "test (3.12)" },
+          { "context": "build" },
+          { "context": "dco" },
+          { "context": "commitlint" },
+          { "context": "pr-title" },
+          { "context": "dependency-review" }
+        ]
+      }
+    },
+    { "type": "non_fast_forward" },
+    { "type": "deletion" }
+  ]
+}

--- a/docs/rulesets/tags-v.json
+++ b/docs/rulesets/tags-v.json
@@ -1,0 +1,17 @@
+{
+  "name": "tags-v",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/tags/v*"], "exclude": [] }
+  },
+  "bypass_actors": [
+    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" },
+    { "actor_type": "Integration", "actor_id": 15368, "bypass_mode": "always" }
+  ],
+  "rules": [
+    { "type": "creation" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}


### PR DESCRIPTION
Item F de #27 : livrer le JSON des deux rulesets comme artefact reproductible.

`docs/rulesets/main.json` et `docs/rulesets/tags-v.json` sont les payloads d'entrée pour `gh api -X POST repos/.../rulesets --input <fichier>`. Après création, on peut les remplacer par l'export canonique (`gh api repos/.../rulesets/<id>`) si on veut la forme exacte renvoyée par GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)