### PR TITLE
fix: ruleset tags v* — retirer bypass Integration et règle creation

### DIFF
--- a/docs/rulesets/tags-v.json
+++ b/docs/rulesets/tags-v.json
@@ -6,11 +6,9 @@
     "ref_name": { "include": ["refs/tags/v*"], "exclude": [] }
   },
   "bypass_actors": [
-    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" },
-    { "actor_type": "Integration", "actor_id": 15368, "bypass_mode": "always" }
+    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" }
   ],
   "rules": [
-    { "type": "creation" },
     { "type": "deletion" },
     { "type": "non_fast_forward" }
   ]


### PR DESCRIPTION
`gh api -X POST …/rulesets --input docs/rulesets/tags-v.json` échoue en **422** : `Actor GitHub Actions integration must be part of the ruleset source or owner organization` — un bypass `actor_type: Integration` n'est pas accepté sur un ruleset de dépôt **utilisateur**.

Ce bypass servait à autoriser release-please à **créer** les tags `v*`. Correctif : retirer la règle `creation`. Restent `deletion` + `non_fast_forward` (l'essentiel de la protection), bypass `Repository admin` conservé. Cohérent avec #26 (« la restriction de création a une valeur moindre — release-please crée les tags via l'API, pas par `git push` »).

Après merge : `gh api -X POST repos/davidouagne/datahub-healthdcat-ap-exporter/rulesets --input docs/rulesets/tags-v.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)