### PR TITLE
fix: ruleset tags v* sans bypass Integration ni règle creation

### DIFF
--- a/docs/rulesets/tags-v.json
+++ b/docs/rulesets/tags-v.json
@@ -6,11 +6,9 @@
     "ref_name": { "include": ["refs/tags/v*"], "exclude": [] }
   },
   "bypass_actors": [
-    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" },
-    { "actor_type": "Integration", "actor_id": 15368, "bypass_mode": "always" }
+    { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" }
   ],
   "rules": [
-    { "type": "creation" },
     { "type": "deletion" },
     { "type": "non_fast_forward" }
   ]


### PR DESCRIPTION
Remplace #48 (sujet de commit à 73 c. → recalé par commitlint).

`gh api POST …/rulesets --input docs/rulesets/tags-v.json` échouait en **422** : `Actor GitHub Actions integration must be part of the ruleset source or owner organization` — bypass `actor_type: Integration` non accepté sur un ruleset de dépôt utilisateur.

Ce bypass devait laisser release-please **créer** les tags `v*`. Correctif : retirer la règle `creation` ; `deletion` + `non_fast_forward` restent (protection réelle), bypass `Repository admin` conservé. Cohérent avec #26.

Après merge : `gh api -X POST repos/davidouagne/datahub-healthdcat-ap-exporter/rulesets --input docs/rulesets/tags-v.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)