### PR TITLE
fix(audit): job pip-audit vert + signalement par issue fiabilisé

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,6 +2,11 @@ name: Audit dépendances
 
 # Veille de fond, complémentaire de la barrière PR (`ci.yml`) : rejoue
 # `pip-audit` chaque semaine contre le lockfile verrouillé. ADR-0003 / #18.
+#
+# Design : le job `audit` reste VERT tant que `pip-audit` s'exécute
+# correctement — une vulnérabilité connue est un constat, pas un échec de CI,
+# et se signale par une issue `dependencies`. Le job ne rougit que si
+# `pip-audit` lui-même échoue (réseau, résolution, rapport illisible).
 on:
   schedule:
     - cron: "0 6 * * 1" # lundi 06:00 UTC
@@ -15,10 +20,13 @@ concurrency:
 
 jobs:
   audit:
-    name: pip-audit (bloquant)
+    name: pip-audit
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      vulns: ${{ steps.audit.outputs.vulns }}
+      summary: ${{ steps.audit.outputs.summary }}
     steps:
       - uses: actions/checkout@v7
 
@@ -32,12 +40,46 @@ jobs:
         run: uv sync --frozen
 
       - name: pip-audit
-        run: uv run pip-audit
+        id: audit
+        run: |
+          set -euo pipefail
+
+          # pip-audit sort en code 1 aussi bien sur « vulnérabilité trouvée »
+          # que sur erreur fatale : on ne se fie pas au code retour mais au
+          # rapport JSON. Pas de rapport lisible => vraie panne => job rouge.
+          set +e
+          uv run pip-audit --format json --output audit.json --progress-spinner off
+          rc=$?
+          set -e
+
+          if ! jq -e . audit.json > /dev/null 2>&1; then
+            echo "::error::pip-audit n'a pas produit de rapport JSON exploitable (code retour $rc)."
+            exit 1
+          fi
+
+          vulns=$(jq '[.dependencies[]? | (.vulns // [])[]] | length' audit.json)
+          echo "vulns=$vulns" >> "$GITHUB_OUTPUT"
+
+          if [ "$vulns" -eq 0 ]; then
+            echo "Aucune vulnérabilité connue dans les dépendances verrouillées."
+            exit 0
+          fi
+
+          summary=$(jq -r '
+            [ .dependencies[]? as $d
+              | ($d.vulns // [])[]
+              | "\($d.name) \($d.version) → \(.id) (corrigé en \((.fix_versions // ["?"]) | join(", ")))"
+            ] | unique | join("; ")' audit.json)
+          echo "summary=$summary" >> "$GITHUB_OUTPUT"
+
+          echo "$vulns vulnérabilité(s) connue(s) :"
+          jq -r '.dependencies[]? | select((.vulns // []) | length > 0)
+            | .name + " " + .version + " : " + ([.vulns[].id] | unique | join(", "))' audit.json
 
   open-issue:
-    name: Ouvrir une issue à l'échec
+    name: Ouvrir une issue si vulnérabilité
     needs: audit
-    if: failure()
+    if: needs.audit.outputs.vulns != '' && needs.audit.outputs.vulns != '0'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -45,9 +87,15 @@ jobs:
       - name: Créer l'issue « dependencies » (dédoublonnée par titre)
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh déduit sinon le dépôt du `git remote` local : ce job n'a pas de
+          # checkout, d'où l'échec « not a git repository » (run 33396751174).
+          GH_REPO: ${{ github.repository }}
           TITLE: "pip-audit : vulnérabilité connue dans les dépendances"
+          SUMMARY: ${{ needs.audit.outputs.summary }}
           RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         run: |
+          set -euo pipefail
+
           gh label create dependencies \
             --color BFD4F2 \
             --description "Sécurité et mises à jour de dépendances" \
@@ -66,8 +114,10 @@ jobs:
           gh issue create \
             --title "$TITLE" \
             --label dependencies \
-            --body "Le workflow \`audit.yml\` a échoué : \`pip-audit\` a trouvé au moins une vulnérabilité connue dans les dépendances verrouillées.
+            --body "\`pip-audit\` (workflow \`audit.yml\`) a trouvé au moins une vulnérabilité connue dans les dépendances verrouillées.
 
-          Détail dans les logs du run : $RUN_URL
+          $SUMMARY
+
+          Détail complet dans les logs du run : $RUN_URL
 
           Cette issue est dédoublonnée par titre — elle ne sera pas rouverte tant qu'elle reste ouverte."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# datahub-healthdcat-ap-exporter
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs live as GitHub issues in `davidouagne/datahub-healthdcat-ap-exporter`,
+managed with the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by
+`/domain-modeling`). See `docs/agents/domain.md`.

--- a/docs/adr/0003-chaine-ci-cd.md
+++ b/docs/adr/0003-chaine-ci-cd.md
@@ -46,8 +46,12 @@ Le plafond de la matrice Python est calé sur la fourchette supportée par
 `ignore: ["tests/**"]`.
 
 **Audit** : `pip-audit` advisory à chaque PR + workflow dédié
-`.github/workflows/audit.yml` (cron hebdomadaire lundi 06:00 UTC, **bloquant**,
-ouvre une issue `dependencies` à l'échec, dédoublonnée par titre).
+`.github/workflows/audit.yml` (cron hebdomadaire lundi 06:00 UTC). Le job
+`audit` reste **vert** tant que `pip-audit` s'exécute correctement ; une
+vulnérabilité connue est un constat, pas un échec de CI, et ouvre une issue
+`dependencies` dédoublonnée par titre (job `open-issue` conditionné au nombre
+de vulnérabilités du rapport JSON, `issues: write` isolé). Le job ne rougit
+que si `pip-audit` lui-même échoue (réseau, résolution, rapport illisible).
 
 `.pre-commit-config.yaml` de base fourni (`ruff` en `language: system` via
 `uv run` pour aligner les versions sur `uv.lock` ; `mypy` exclu), **non imposé**

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/uv.lock
+++ b/uv.lock
@@ -893,7 +893,7 @@ wheels = [
 
 [[package]]
 name = "dh-healthdcat"
-version = "0.1.0"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "acryl-datahub" },


### PR DESCRIPTION
## Résumé

Le run programmé [`audit.yml` #33396751174](https://github.com/davidouagne/datahub-healthdcat-ap-exporter/actions/runs/33396751174) a échoué **deux fois** : `pip-audit` a trouvé `setuptools` / `PYSEC-2026-3447` (job rouge, voulu), puis le job `open-issue` a planté sur `fatal: not a git repository` — il n'a pas de checkout et `gh` tentait de déduire le dépôt du `git remote` local. **Aucune issue n'a été créée.**

### `fix(audit)` — job vert + issue seule, signalement réparé

Design revu (demande explicite) : le job `audit` reste **vert** tant que `pip-audit` s'exécute correctement. Une vulnérabilité connue est un constat, pas un échec de CI.

- `pip-audit` écrit un rapport JSON ; on tranche sur son **contenu**, pas sur le code retour (`1` aussi bien pour « vuln trouvée » que pour erreur fatale). Rapport illisible ⇒ vraie panne ⇒ job rouge.
- Le job expose `vulns` (nombre) et `summary` (`paquet version → ID (corrigé en …)`) en sorties.
- `open-issue` se déclenche sur `vulns > 0` au lieu de `failure()`, garde `issues: write` isolé, reçoit `GH_REPO` (plus besoin de checkout) et injecte `summary` dans le corps de l'issue. Dédoublonnage par titre inchangé.
- `docs/adr/0003` : le paragraphe « Audit » (« **bloquant**, ouvre une issue à l'échec ») réécrit pour le nouveau design.

`PYSEC-2026-3447` n'est **volontairement pas ignorée** : non corrigeable tant que `acryl-datahub` plafonne `setuptools<82` (fix en `83`). L'issue `dependencies` matérialisera le suivi sans polluer l'historique CI en rouge.

### `chore(deps)` — resync `uv.lock`

release-please avait bougé `pyproject.toml` en `0.1.2` sans régénérer le lockfile (encore `0.1.0`). `uv sync --frozen` tolère ce drift, pas `--locked`. Diff d'une ligne, aucun remaniement de dépendances.

### `chore` — setup agentic

`CLAUDE.md` + `docs/agents/{issue-tracker,domain}.md` (scaffolding des skills, jusqu'ici non versionné).

## Checklist

- [x] Chaque commit est signé DCO et est un Conventional Commit valide, sujet ≤ 72, sans point final.
- [x] Historique de branche propre (rebase avant ouverture).
- [x] Sans objet : aucun code applicatif touché (workflow YAML, `uv.lock`, `.md`) ; la CI de la PR exécute `pytest`.
- [x] Aucune correspondance DataHub → HealthDCAT-AP modifiée.
- [x] Aucun vocabulaire contrôlé modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

