### PR TITLE
fix(release): recaler uv.lock sur le bump de version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,45 @@ jobs:
           # n'expose pas cet input) — le commit chore(main): release … du bot
           # porte ainsi un Signed-off-by et passe le check dco (ADR-0002).
 
+      # release-please bumpe `pyproject.toml` mais ignore l'entrée du paquet
+      # racine dans `uv.lock` (`[[package]] name = "dh-healthdcat"`), d'où un
+      # décalage de version systématique à chaque release. On réaligne le
+      # lockfile directement sur la branche de la PR de release.
+      - name: Checkout de la branche de la PR de release
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+
+      - name: Installer uv
+        if: ${{ steps.release.outputs.pr }}
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Synchroniser uv.lock avec pyproject.toml
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # `uv lock` sans --upgrade : recale la seule version du paquet racine
+          # sur pyproject.toml, sans reresoudre les dépendances.
+          uv lock
+
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock déjà synchrone — rien à faire."
+            exit 0
+          fi
+
+          git add uv.lock
+          git commit -s -m "chore(main): synchroniser uv.lock avec pyproject.toml"
+          git push origin "HEAD:$RELEASE_BRANCH"
+
   build:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}

--- a/docs/adr/0003-chaine-ci-cd.md
+++ b/docs/adr/0003-chaine-ci-cd.md
@@ -65,6 +65,11 @@ Mode **manifeste** (`release-please-config.json` +
 
 - `[project].version` de `pyproject.toml` reste **statique**, bumpé nativement
   (PEP 621). Pas de `__version__` dans le code ; pas de `extra-files`.
+- `uv.lock` porte aussi la version du paquet racine (`[[package]]
+  name = "dh-healthdcat"`), que release-please ne bumpe pas → décalage
+  systématique à chaque release. Recalé par un step du job `release-please`
+  (`uv lock` + commit `chore(main)` signé DCO sur la branche de la PR de
+  release) plutôt que par un `extra-files` TOML fragile sur un fichier généré.
 - `bootstrap-sha` figé au HEAD d'adoption → aucun changelog rétroactif.
 - Pré-1.0 : `bump-minor-pre-major: true` (un breaking bumpe le minor, pas
   `1.0.0`), `bump-patch-for-minor-pre-major: false`. Passage à `1.0.0` =


### PR DESCRIPTION
## Résumé

`release-please` bumpe `[project].version` de `pyproject.toml` mais **pas** l'entrée du paquet racine dans `uv.lock` (`[[package]] name = "dh-healthdcat"` → `version = …`). À chaque release, `uv.lock` prend donc **un retard d'une version** de façon systématique.

- Constaté sur la PR de release **#55** (`chore(main): release 0.1.3`) : elle touche `pyproject.toml`, `.release-please-manifest.json`, `CHANGELOG.md` — jamais `uv.lock`.
- Corrigé à la main dans #54 (`0.1.0 → 0.1.2`), mais le drift se reforme au cycle suivant.
- `uv sync --frozen` (CI) tolère ce décalage ; `uv lock --locked` non.

## Correctif

Le job `release-please` de `release.yml` gagne trois steps, **conditionnés à l'existence d'une PR de release** (`steps.release.outputs.pr`) :

1. checkout de la branche de la PR de release (`ref: fromJSON(...).headBranchName`) ;
2. installation de `uv` ;
3. `uv lock` (sans `--upgrade` : recale la seule version du paquet racine, aucune reresolution) ; si `uv.lock` a bougé → commit `chore(main): synchroniser uv.lock avec pyproject.toml` signé DCO (identité `github-actions[bot]`) poussé sur la branche de la PR.

Idempotent : si `uv.lock` est déjà synchrone, le step ne commit rien. Sur une mise à jour ultérieure de la PR de release, release-please regénère sa branche puis le step réapplique la synchro.

### Pourquoi pas `extra-files`

L'updater TOML de release-please sur un chemin de tableau filtré (`$.package[?(@.name=="dh-healthdcat")].version`) est fragile, et `uv.lock` est un fichier généré : le faire écrire par `uv` lui-même est plus sûr.

## Suite

Une fois cette PR fusionnée, le push sur `main` relance `release.yml` → **#55 recevra le commit de synchro `uv.lock` → 0.1.3** avant sa propre fusion.

## Checklist

- [x] Commits signés DCO, Conventional Commits valides, sujet ≤ 72, sans point final.
- [x] Historique de branche propre.
- [x] Sans objet : aucun code applicatif touché (workflow YAML + ADR) ; la CI de la PR exécute `pytest`.
- [x] Aucune correspondance DataHub → HealthDCAT-AP modifiée.
- [x] Aucun vocabulaire contrôlé modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
