### PR TITLE
fix(release): garder fromJSON du sync uv.lock + dispatch de rattrapage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,20 @@ name: release
 # posé par release-please via GITHUB_TOKEN ne déclenche aucun workflow, donc
 # build / publish / smoke sont des jobs de CE workflow, gardés par
 # `release_created == 'true'` et exécutés dans le contexte push/main.
+#
+# `workflow_dispatch` (input `publish_tag`) : filet de rattrapage quand le run
+# automatique d'une release a échoué APRÈS la pose du tag (job `release-please`
+# rouge => build / publish jamais exécutés). Rejoue build → publish → smoke
+# sur un tag déjà existant.
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      publish_tag:
+        description: "Tag existant (ex. v0.1.3) à (re)construire et publier sur PyPI."
+        type: string
+        required: true
 
 permissions: {}
 
@@ -39,11 +50,16 @@ jobs:
       # racine dans `uv.lock` (`[[package]] name = "dh-healthdcat"`), d'où un
       # décalage de version systématique à chaque release. On réaligne le
       # lockfile directement sur la branche de la PR de release.
+      #
+      # `steps.release.outputs.pr` vaut `''` sur un run qui FUSIONNE la PR de
+      # release : le `&& … || ''` court-circuite `fromJSON('')` (qui lèverait
+      # « Error reading JToken »). Le `if:` seul ne suffit pas — GitHub évalue
+      # le `env:` d'un step même quand son `if:` est faux.
       - name: Checkout de la branche de la PR de release
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v7
         with:
-          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          ref: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
 
       - name: Installer uv
         if: ${{ steps.release.outputs.pr }}
@@ -54,7 +70,7 @@ jobs:
       - name: Synchroniser uv.lock avec pyproject.toml
         if: ${{ steps.release.outputs.pr }}
         env:
-          RELEASE_BRANCH: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
         run: |
           set -euo pipefail
 
@@ -76,14 +92,17 @@ jobs:
 
   build:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    # push d'une release taguée, OU rattrapage manuel sur un tag existant.
+    if: ${{ needs.release-please.outputs.release_created == 'true' || inputs.publish_tag }}
     runs-on: ubuntu-latest
     permissions:
       contents: write # gh release upload
+    env:
+      TAG: ${{ inputs.publish_tag || needs.release-please.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ inputs.publish_tag || needs.release-please.outputs.tag_name }}
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@v7
@@ -99,7 +118,7 @@ jobs:
       - name: Attacher les artefacts à la GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*
+        run: gh release upload "$TAG" dist/*
 
       - uses: actions/upload-artifact@v7
         with:
@@ -132,8 +151,9 @@ jobs:
     steps:
       - name: Installer depuis PyPI et fumer la CLI
         env:
-          VERSION: ${{ needs.release-please.outputs.version }}
+          TAG: ${{ inputs.publish_tag || needs.release-please.outputs.tag_name }}
         run: |
+          VERSION="${TAG#v}"
           python -m venv /tmp/smoke
           for i in 1 2 3 4 5; do
             /tmp/smoke/bin/pip install "dh-healthdcat==$VERSION" && break

--- a/docs/adr/0003-chaine-ci-cd.md
+++ b/docs/adr/0003-chaine-ci-cd.md
@@ -83,16 +83,21 @@ Mode **manifeste** (`release-please-config.json` +
 
 ## 3. Publication PyPI (`.github/workflows/release.yml`)
 
-Un seul workflow, `on: push: branches: [main]`, `permissions: {}`,
-`concurrency: { group: release, cancel-in-progress: false }`. Quatre jobs
-enchaînés, tous gardés par
-`if: needs.release-please.outputs.release_created == 'true'` :
+Un seul workflow, `on: push: branches: [main]` (+ `workflow_dispatch`),
+`permissions: {}`, `concurrency: { group: release, cancel-in-progress: false }`.
+Quatre jobs enchaînés, `build` → `publish` → `smoke` gardés par
+`if: needs.release-please.outputs.release_created == 'true' || inputs.publish_tag` :
 
 `release-please` → `build` → `publish` → `smoke`.
 
 - **Pas de PAT ni de GitHub App** : le tag posé par `GITHUB_TOKEN` ne déclenchant
   aucun workflow, le job `publish` vit dans le même workflow, gardé par la sortie
   `release_created` (et non par un trigger `on: release` ou `on: push: tags`).
+- **Rattrapage** : `workflow_dispatch` avec input `publish_tag` (ex. `v0.1.3`)
+  rejoue `build` → `publish` → `smoke` sur un tag déjà posé, pour le cas où le
+  run automatique a échoué *après* le tag (job `release-please` rouge). Sans
+  ce filet, une version tagguée mais non publiée n'a aucun chemin de reprise
+  (`release_created` n'est vrai qu'au run qui crée la release).
 - `build` (`contents: write`) : checkout du tag (`ref: tag_name`,
   `persist-credentials: false`), `uv build --no-sources`, `uvx twine check`,
   `gh release upload` des artefacts sur la Release créée par release-please,


### PR DESCRIPTION
## Résumé

Le step **« Synchroniser uv.lock »** (ajouté en #57) casse le run de release au moment où la **PR de release est fusionnée** : `steps.release.outputs.pr` vaut alors `''`, et `fromJSON('')` lève

```
The template is not valid. .github/workflows/release.yml (Line: 57, Col: 27):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

Le `if: ${{ steps.release.outputs.pr }}` ne protège pas : GitHub évalue le bloc `env:` d'un step **même quand son `if:` est faux**. J'ai testé #57 uniquement sur le chemin « PR de release mise à jour » (`pr` non vide), jamais sur « PR de release fusionnée ».

### Dégâts observés — run [33620074933](https://github.com/davidouagne/datahub-healthdcat-ap-exporter/actions/runs/33620074933) (merge de #55)

| | État |
|---|---|
| Tag `v0.1.3` + Release GitHub | ✅ créés (le step release-please avait déjà réussi) |
| `pyproject.toml` / `uv.lock` sur `main` | ✅ `0.1.3` (la synchro a marché au run précédent) |
| **PyPI** | ❌ **`0.1.3` absent** — job `release-please` rouge ⇒ `build` / `publish` / `smoke` skippés |
| Release GitHub `v0.1.3` | ⚠️ 0 asset |

## Correctifs

1. **Garde `fromJSON`** sur les deux usages (checkout `ref:` + `env:`) :
   `${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}` — court-circuit, `fromJSON` n'est plus appelé sur `''`.
2. **`workflow_dispatch` + input `publish_tag`** : rejoue `build` → `publish` → `smoke` sur un tag existant. `build` / `smoke` gardés par `release_created == 'true' || inputs.publish_tag` ; `TAG = inputs.publish_tag || tag_name` ; `VERSION="${TAG#v}"` pour le smoke. Sans ce filet, une version tagguée mais non publiée n'a **aucun chemin de reprise**.
3. ADR-0003 §3 mis à jour.

## Suite (après merge)

Republier `0.1.3` :

```
gh workflow run release.yml -f publish_tag=v0.1.3
```

→ `build` (checkout `v0.1.3`, `uv build`, upload assets sur la Release) → `publish` (Trusted Publishing OIDC) → `smoke`. Le job `release-please` tournera aussi (ouvrira/mettra à jour la PR de release `0.1.4` pour ce `fix:`), sans incidence sur le rattrapage.

## Checklist

- [x] Commits signés DCO, Conventional Commits valides, sujet ≤ 72, sans point final.
- [x] Historique de branche propre.
- [x] Sans objet : aucun code applicatif touché (workflow YAML + ADR) ; la CI de la PR exécute `pytest`.
- [x] Aucune correspondance DataHub → HealthDCAT-AP modifiée.
- [x] Aucun vocabulaire contrôlé modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
